### PR TITLE
Avoid double-nullables in docs

### DIFF
--- a/bin/generate-docs.php
+++ b/bin/generate-docs.php
@@ -234,7 +234,7 @@ final class DocsGen {
 
     if ($t->isNullable()) {
       invariant(
-        Str\slice($text, 0, 1) === '?',
+        Str\starts_with($text, '?'),
         "'%s' is nullable, but doesn't start with '?'",
         $text,
       );


### PR DESCRIPTION
Introduced by https://github.com/hhvm/definition-finder/releases/tag/v1.6.0