### PR TITLE
Don't use 'Math' without a 'use' statement in VecSelectTest

### DIFF
--- a/tests/vec/VecSelectTest.php
+++ b/tests/vec/VecSelectTest.php
@@ -10,8 +10,7 @@
  */
 
 use HH\Lib\Vec as VecHSL;
-use HH\Lib\Math as MathHSL;
-use HH\Lib\{C, Str};
+use HH\Lib\{C, Math, Str};
 use function \Facebook\FBExpect\expect;
 
 /**
@@ -397,7 +396,7 @@ final class VecSelectTest extends PHPUnit_Framework_TestCase {
     Traversable<Tv> $traversable,
     int $sample_size,
   ): void {
-    $expected_size = MathHSL\min(C\count(vec($traversable)), $sample_size);
+    $expected_size = Math\min(C\count(vec($traversable)), $sample_size);
     expect(C\count(VecHSL\sample($traversable, $sample_size)))
       ->toBeSame($expected_size);
   }

--- a/tests/vec/VecSelectTest.php
+++ b/tests/vec/VecSelectTest.php
@@ -10,6 +10,7 @@
  */
 
 use HH\Lib\Vec as VecHSL;
+use HH\Lib\Math as MathHSL;
 use HH\Lib\{C, Str};
 use function \Facebook\FBExpect\expect;
 
@@ -396,7 +397,7 @@ final class VecSelectTest extends PHPUnit_Framework_TestCase {
     Traversable<Tv> $traversable,
     int $sample_size,
   ): void {
-    $expected_size = Math\min(C\count(vec($traversable)), $sample_size);
+    $expected_size = MathHSL\min(C\count(vec($traversable)), $sample_size);
     expect(C\count(VecHSL\sample($traversable, $sample_size)))
       ->toBeSame($expected_size);
   }


### PR DESCRIPTION
Broken by cdb25b9b10604206fc5d539711ee884b32a07df9

Math\ is undefined outside of FB. Exists in FB due to HHVM and hack being
configured to auto alias it.

Still waiting on an internal deployment to make 'use namespace' available, then these will all be unified.