### PR TITLE
Update dependencies

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -57,16 +57,16 @@
         },
         {
             "name": "facebook/definition-finder",
-            "version": "v1.6.1",
+            "version": "v1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/definition-finder.git",
-                "reference": "6bcf70d3962994679be30968b05183f106c0f2b8"
+                "reference": "3d1faa5f7d9c954ca1793cddeaf187e3631c4ed8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/definition-finder/zipball/6bcf70d3962994679be30968b05183f106c0f2b8",
-                "reference": "6bcf70d3962994679be30968b05183f106c0f2b8",
+                "url": "https://api.github.com/repos/hhvm/definition-finder/zipball/3d1faa5f7d9c954ca1793cddeaf187e3631c4ed8",
+                "reference": "3d1faa5f7d9c954ca1793cddeaf187e3631c4ed8",
                 "shasum": ""
             },
             "require": {
@@ -95,32 +95,32 @@
                 "hack",
                 "hhvm"
             ],
-            "time": "2017-08-14T18:51:43+00:00"
+            "time": "2017-08-25T16:56:25+00:00"
         },
         {
             "name": "facebook/hhvm-autoload",
-            "version": "v1.4.1",
+            "version": "v1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hhvm-autoload.git",
-                "reference": "cd4aed7a0b4a5cf889ed9ab1a27d4b777258e15c"
+                "reference": "f1a805e38e51fef5eb0422067d2c87dbc79f0f8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hhvm-autoload/zipball/cd4aed7a0b4a5cf889ed9ab1a27d4b777258e15c",
-                "reference": "cd4aed7a0b4a5cf889ed9ab1a27d4b777258e15c",
+                "url": "https://api.github.com/repos/hhvm/hhvm-autoload/zipball/f1a805e38e51fef5eb0422067d2c87dbc79f0f8b",
+                "reference": "f1a805e38e51fef5eb0422067d2c87dbc79f0f8b",
                 "shasum": ""
             },
             "require": {
-                "91carriage/phpunit-hhi": "^5.1",
+                "91carriage/phpunit-hhi": "^5.5",
                 "composer-plugin-api": "^1.0",
                 "facebook/definition-finder": "^1.0",
                 "fredemmott/hack-error-suppressor": "^1.0",
-                "fredemmott/type-assert": "^1.1",
-                "hhvm": "^3.12"
+                "hhvm": "^3.12",
+                "hhvm/type-assert": "^2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.1"
+                "phpunit/phpunit": "^5.5"
             },
             "bin": [
                 "bin/hh-autoload"
@@ -142,7 +142,7 @@
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "time": "2017-07-24T17:00:40+00:00"
+            "time": "2017-09-04T18:41:11+00:00"
         },
         {
             "name": "fredemmott/hack-error-suppressor",
@@ -182,17 +182,17 @@
             "time": "2017-05-02T03:07:37+00:00"
         },
         {
-            "name": "fredemmott/type-assert",
-            "version": "v1.1",
+            "name": "hhvm/type-assert",
+            "version": "v2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/fredemmott/type-assert.git",
-                "reference": "38460b438ca85701585abe471d944c678d242847"
+                "url": "https://github.com/hhvm/type-assert.git",
+                "reference": "fcd2cdc238302242b0da207fe395d6f7f2e8a2a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fredemmott/type-assert/zipball/38460b438ca85701585abe471d944c678d242847",
-                "reference": "38460b438ca85701585abe471d944c678d242847",
+                "url": "https://api.github.com/repos/hhvm/type-assert/zipball/fcd2cdc238302242b0da207fe395d6f7f2e8a2a6",
+                "reference": "fcd2cdc238302242b0da207fe395d6f7f2e8a2a6",
                 "shasum": ""
             },
             "require": {
@@ -209,15 +209,12 @@
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "ISC"
-            ],
             "description": "Convert untyped data to typed data",
             "keywords": [
                 "TypeAssert",
                 "hack"
             ],
-            "time": "2017-02-15T02:26:23+00:00"
+            "time": "2017-08-29T21:00:54+00:00"
         }
     ],
     "packages-dev": [
@@ -405,22 +402,22 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.2.0",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "46f7e8bb075036c92695b15a1ddb6971c751e585"
+                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/46f7e8bb075036c92695b15a1ddb6971c751e585",
-                "reference": "46f7e8bb075036c92695b15a1ddb6971c751e585",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/4aada1f93c72c35e22fb1383b47fee43b8f1d157",
+                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5",
                 "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.4.0",
+                "phpdocumentor/type-resolver": "^0.3.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
@@ -446,20 +443,20 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-07-15T11:38:20+00:00"
+            "time": "2017-08-08T06:39:58+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.4.0",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/fb3933512008d8162b3cdf9e18dba9309b7c3773",
+                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773",
                 "shasum": ""
             },
             "require": {
@@ -493,26 +490,26 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14T14:27:02+00:00"
+            "time": "2017-06-03T08:32:36+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.0",
+            "version": "v1.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
+                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
+                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
                 "sebastian/comparator": "^1.1|^2.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
@@ -523,7 +520,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.7.x-dev"
                 }
             },
             "autoload": {
@@ -556,7 +553,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2017-09-04T11:05:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1463,20 +1460,20 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.3.6",
+            "version": "v3.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "ddc23324e6cfe066f3dd34a37ff494fa80b617ed"
+                "reference": "1d8c2a99c80862bdc3af94c1781bf70f86bccac0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/ddc23324e6cfe066f3dd34a37ff494fa80b617ed",
-                "reference": "ddc23324e6cfe066f3dd34a37ff494fa80b617ed",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/1d8c2a99c80862bdc3af94c1781bf70f86bccac0",
+                "reference": "1d8c2a99c80862bdc3af94c1781bf70f86bccac0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "require-dev": {
                 "symfony/console": "~2.8|~3.0"
@@ -1514,7 +1511,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-07-23T12:43:26+00:00"
+            "time": "2017-07-29T21:54:42+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
Replaces the indirect dependency on fredemmott/type-assert with hhvm/type-assert;
fredemmott/type-assert is deprecated in favor of hhvm/type-assert, which leads
composer to display a warning.