### PR TITLE
Remove apt-get commands from travis.sh

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 set -ex
 hhvm --version
-apt-get update -y
-apt-get install -y wget curl git
 curl https://getcomposer.org/installer | hhvm -d hhvm.jit=0 --php -- /dev/stdin --install-dir=/usr/local/bin --filename=composer
 
 cd /var/source


### PR DESCRIPTION
wget, curl, and git are now in the base docker images, so they're unneeded.

They're also extremely time consuming, so this makes our test runs a fair
bit faster.