### PR TITLE
OSS configuration updates

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -1,3 +1,5 @@
 assume_php=false
-enable_experimental_tc_features = safe_pass_by_ref, safe_array, safe_vector_array, contextual_inference
+enable_experimental_tc_features = no_fallback_in_namespaces
+safe_array = true
+safe_vector_array = true
 ignored_paths = [ "vendor/.+/tests/.+" ]

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,14 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 set -ex
 hhvm --version
-curl https://getcomposer.org/installer | hhvm -d hhvm.jit=0 --php -- /dev/stdin --install-dir=/usr/local/bin --filename=composer
 
-cd /var/source
-hhvm -d hhvm.jit=0 /usr/local/bin/composer install
+composer install
 
-hh_server --check $(pwd)
-hhvm -d hhvm.php7.all=0 -d hhvm.jit=0 vendor/bin/phpunit
-hhvm -d hhvm.php7.all=1 -d hhvm.jit=0 vendor/bin/phpunit
+hh_client
 
-sed -i '/enable_experimental_tc_features/d' .hhconfig
+hhvm vendor/bin/phpunit tests/
+
+echo > .hhconfig
 hh_server --check $(pwd)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,9 @@
-sudo: required
-language: generic
-services:
- - docker
-env:
-  matrix:
-   - HHVM_VERSION=latest
-   - HHVM_VERSION=nightly
-  global:
-    secure: T6Tu15IDluus8OskgpPk4aV3Ryr9KBPvilZ4d7B9k6yDmlZ4L6KiS55bF1fKCA45PGIvzGEFXlpf31OtYBEKcb67Jz9OoQCWAV1VfS5eR+qw9Wjm4TMRF0q130ohhXKaZfOZrgFPUlEMFram6Lha9UpUWwF/3BTd3/Mcm+q2scCnik1IaLwa8aGIk5RvAyqGISgfptUp39Uiq21qZx/HXoc+XVqoV6zJ10Utu3Nrm6ecE4qI7eaYQPMfB6If8UQ3SMg24tRzqGd7XWbzpIYUihyeREhWzFMuYBKp+o8KLbehPtLNKXygIGMhMbc8QPKX2xcyuiJ2K71Pe7Rql44XbWFeRq9KgXMqzyqI+jPEn92s/t+2l3A55M5oMu5cxNcC0QQNa+5hhBqPgK8OCTSfoIVgmIX4Rg6s9LCUP/EymwZIqSJW+Wie74IMbi9h+uWSt8yuxSRNd5zYibogbaneaj3mELdHsVE37K2XumlfYB6vy1MxE0yOcUdqj3yPkUYHeVTpR7WLSIq+VF2vOOgD2gNweeY6hti/Dc0Jat3beiWVYNjfE9gwo3DdOmKaDIidVG7+Oyollzq29CcpAzsJnOedOBpiJVz6k9/CHjXnQVJICTRYZZ8cIlyeGUtTJ1xuX8GXlJnfIbEGscboUhB0zSKAx9FcUw8XInyfCX7gDCs=
-install:
- - docker pull hhvm/hhvm:$HHVM_VERSION
+language: php
+php:
+ - hhvm
+ - hhvm-3.24
+ - hhvm-nightly
 script:
- - env | egrep '^(HHVM_VERSION|GITHUB_API_KEY|TRAVIS_EVENT_TYPE)=' > ./env-list # Dump to file to avoid leaking the token to TravisCI output
- - docker run --env-file ./env-list -v $(pwd):/var/source hhvm/hhvm:$HHVM_VERSION /var/source/.travis.sh
+ - ./.travis.sh
 notifications:
   webhooks: https://code.facebook.com/travis/webhook/

--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,12 @@
   "name": "hhvm/hsl",
   "description": "The Hack Standard Library",
   "require-dev": {
-    "hhvm": "^3.23.2",
     "91carriage/phpunit-hhi": "^5.7",
     "phpunit/phpunit": "^5.7",
-    "facebook/fbexpect": "^0.4",
-    "facebook/definition-finder": "^1.6.1"
+    "facebook/fbexpect": "^0.4"
   },
   "require": {
+    "hhvm": "^3.23.2",
     "hhvm/hhvm-autoload": "^1.4"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,50 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "feb95f46d0a9690950607669f5b4745e",
+    "content-hash": "d4a246a5c4aa57b4b0c826c3434e6744",
     "packages": [
-        {
-            "name": "facebook/definition-finder",
-            "version": "v1.6.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/hhvm/definition-finder.git",
-                "reference": "e39f5e2a6e3636e5a8cdb1670188c5c728b13470"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/definition-finder/zipball/e39f5e2a6e3636e5a8cdb1670188c5c728b13470",
-                "reference": "e39f5e2a6e3636e5a8cdb1670188c5c728b13470",
-                "shasum": ""
-            },
-            "require": {
-                "hhvm": "~3.23"
-            },
-            "require-dev": {
-                "91carriage/phpunit-hhi": "~5.1",
-                "hhvm/systemlib-extractor": "~1.0",
-                "phpunit/phpunit": "~5.1"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ],
-                "files": [
-                    "autoload_files.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "description": "Find definitions in PHP or Hack files. Useful for autoloaders.",
-            "homepage": "https://github.com/hhvm/definitions-finder",
-            "keywords": [
-                "autoload",
-                "definitions",
-                "hack",
-                "hhvm"
-            ],
-            "time": "2018-01-05T20:56:28+00:00"
-        },
         {
             "name": "fredemmott/hack-error-suppressor",
             "version": "v1.0.1",
@@ -87,21 +45,20 @@
         },
         {
             "name": "hhvm/hhvm-autoload",
-            "version": "v1.5.4",
+            "version": "v1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hhvm-autoload.git",
-                "reference": "20aa3b34de71a337644a146f2abbafe491fd3bb2"
+                "reference": "6ea8fe2cf396a5e9f15d4ef1097ef4d9dcd15eaa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hhvm-autoload/zipball/20aa3b34de71a337644a146f2abbafe491fd3bb2",
-                "reference": "20aa3b34de71a337644a146f2abbafe491fd3bb2",
+                "url": "https://api.github.com/repos/hhvm/hhvm-autoload/zipball/6ea8fe2cf396a5e9f15d4ef1097ef4d9dcd15eaa",
+                "reference": "6ea8fe2cf396a5e9f15d4ef1097ef4d9dcd15eaa",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0",
-                "facebook/definition-finder": "~1.6.4",
                 "fredemmott/hack-error-suppressor": "^1.0",
                 "hhvm": "^3.23"
             },
@@ -133,20 +90,20 @@
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "time": "2018-01-05T21:10:38+00:00"
+            "time": "2018-02-08T22:51:10+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "91carriage/phpunit-hhi",
-            "version": "5.7.1",
+            "version": "5.7.2",
             "source": {
                 "type": "git",
                 "url": "https://git.simon.geek.nz/91-carriage/phpunit-hhi.git",
-                "reference": "6864897f023f111d8b72fb7340c1ef5d0d9f8a45"
+                "reference": "b2ca7d221fa4ac6b4331e0dbc32cdc918ab8b11f"
             },
             "require": {
-                "hhvm": ">=3.12.0"
+                "hhvm": ">=3.23.0"
             },
             "conflict": {
                 "phpunit/phpunit": "<5.7.15"
@@ -184,7 +141,7 @@
                 "phpunit",
                 "testing"
             ],
-            "time": "2017-04-09T02:42:01+00:00"
+            "time": "2018-01-09T08:14:01+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -242,16 +199,16 @@
         },
         {
             "name": "facebook/fbexpect",
-            "version": "v0.4",
+            "version": "v0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/fbexpect.git",
-                "reference": "21e8ea201df6555bcf014a75560426650c7d961b"
+                "reference": "5af28d762b2bf8c6e7c242ce94eacf5136f61459"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/fbexpect/zipball/21e8ea201df6555bcf014a75560426650c7d961b",
-                "reference": "21e8ea201df6555bcf014a75560426650c7d961b",
+                "url": "https://api.github.com/repos/hhvm/fbexpect/zipball/5af28d762b2bf8c6e7c242ce94eacf5136f61459",
+                "reference": "5af28d762b2bf8c6e7c242ce94eacf5136f61459",
                 "shasum": ""
             },
             "require": {
@@ -271,7 +228,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "description": "Unit test helpers for Facebook projects",
-            "time": "2018-01-05T21:25:50+00:00"
+            "time": "2018-02-09T00:09:55+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -778,16 +735,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.26",
+            "version": "5.7.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "7fbc25c13309de0c4c9bb48b7361f1eca34c7fbd"
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7fbc25c13309de0c4c9bb48b7361f1eca34c7fbd",
-                "reference": "7fbc25c13309de0c4c9bb48b7361f1eca34c7fbd",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
                 "shasum": ""
             },
             "require": {
@@ -811,7 +768,7 @@
                 "sebastian/global-state": "^1.1",
                 "sebastian/object-enumerator": "~2.0",
                 "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "~1.0.3|~2.0",
+                "sebastian/version": "^1.0.6|^2.0.1",
                 "symfony/yaml": "~2.1|~3.0|~4.0"
             },
             "conflict": {
@@ -856,7 +813,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-12-17T06:14:38+00:00"
+            "time": "2018-02-01T05:50:59+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1432,16 +1389,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.3",
+            "version": "v3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "25c192f25721a74084272671f658797d9e0e0146"
+                "reference": "eab73b6c21d27ae4cd037c417618dfd4befb0bfe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/25c192f25721a74084272671f658797d9e0e0146",
-                "reference": "25c192f25721a74084272671f658797d9e0e0146",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/eab73b6c21d27ae4cd037c417618dfd4befb0bfe",
+                "reference": "eab73b6c21d27ae4cd037c417618dfd4befb0bfe",
                 "shasum": ""
             },
             "require": {
@@ -1486,20 +1443,20 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-03T07:37:34+00:00"
+            "time": "2018-01-21T19:05:02+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
                 "shasum": ""
             },
             "require": {
@@ -1536,7 +1493,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2018-01-29T19:49:41+00:00"
         }
     ],
     "aliases": [],
@@ -1544,8 +1501,8 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": {
+    "platform": {
         "hhvm": "^3.23.2"
-    }
+    },
+    "platform-dev": []
 }


### PR DESCRIPTION
- update .hhconfig to match what we require for the HSL
- remove dev dependency on definition-finder; this was used for
documentation generation, but we're now doing that on docs.hhvm.com
instead
- HHVM 3.23 is a hard dependency, not a dev dependency
- update other dependencies
- now we're packaging for Trusty again, we don't need to use docker on
Travis; this makes test runs faster
- remove stuff for docs updating from travis config