### PR TITLE
Use HackTest in HSL

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -6,7 +6,7 @@ composer install
 
 hh_client
 
-hhvm vendor/bin/phpunit tests/
+vendor/bin/hacktest tests/
 
 echo > .hhconfig
 hh_server --check $(pwd)

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,15 @@
 {
   "name": "hhvm/hsl",
   "description": "The Hack Standard Library",
+  "extra": {
+    "branch-alias": {
+      "dev-master": "3.x-dev"
+    }
+  },
   "license": "MIT",
   "require-dev": {
-    "91carriage/phpunit-hhi": "^5.7",
-    "phpunit/phpunit": "^5.7",
-    "facebook/fbexpect": "^1.0.0"
+    "facebook/fbexpect": "^1.0.0",
+    "hhvm/hacktest": "^0.1"
   },
   "require": {
     "hhvm": "^3.27.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b6810e33c954e5b0c729dff62cd04253",
+    "content-hash": "fee885927fd018ed423e40ca0df0ea31",
     "packages": [
         {
             "name": "fredemmott/hack-error-suppressor",
@@ -45,16 +45,16 @@
         },
         {
             "name": "hhvm/hhvm-autoload",
-            "version": "v1.6.3",
+            "version": "v1.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hhvm-autoload.git",
-                "reference": "2e3944571aa61b16336bea9254856f5ae4aea48c"
+                "reference": "2808fe06fa850532270c54155c0bdab1bf0f67da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hhvm-autoload/zipball/2e3944571aa61b16336bea9254856f5ae4aea48c",
-                "reference": "2e3944571aa61b16336bea9254856f5ae4aea48c",
+                "url": "https://api.github.com/repos/hhvm/hhvm-autoload/zipball/2808fe06fa850532270c54155c0bdab1bf0f67da",
+                "reference": "2808fe06fa850532270c54155c0bdab1bf0f67da",
                 "shasum": ""
             },
             "require": {
@@ -67,6 +67,7 @@
             },
             "require-dev": {
                 "91carriage/phpunit-hhi": "^5.5",
+                "facebook/fbexpect": "^1.1",
                 "phpunit/phpunit": "^5.5"
             },
             "bin": [
@@ -90,7 +91,7 @@
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "time": "2018-05-08T17:26:24+00:00"
+            "time": "2018-06-12T20:21:07+00:00"
         }
     ],
     "packages-dev": [
@@ -198,17 +199,67 @@
             "time": "2017-07-22T11:58:36+00:00"
         },
         {
-            "name": "facebook/fbexpect",
-            "version": "v1.0.0",
+            "name": "facebook/definition-finder",
+            "version": "v2.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/hhvm/fbexpect.git",
-                "reference": "1b86ba9bcab71242cf8d1a69aaca5ca3774c5ecf"
+                "url": "https://github.com/hhvm/definition-finder.git",
+                "reference": "56e423889c51d315970305d44f70f0a7b9947dc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/fbexpect/zipball/1b86ba9bcab71242cf8d1a69aaca5ca3774c5ecf",
-                "reference": "1b86ba9bcab71242cf8d1a69aaca5ca3774c5ecf",
+                "url": "https://api.github.com/repos/hhvm/definition-finder/zipball/56e423889c51d315970305d44f70f0a7b9947dc4",
+                "reference": "56e423889c51d315970305d44f70f0a7b9947dc4",
+                "shasum": ""
+            },
+            "require": {
+                "hhvm": "^3.26.0",
+                "hhvm/hhast": "3.27.1",
+                "hhvm/hhvm-autoload": "^1.6",
+                "hhvm/hsl": "^3.26.0",
+                "hhvm/type-assert": "^3.2"
+            },
+            "require-dev": {
+                "91carriage/phpunit-hhi": "~5.1",
+                "facebook/fbexpect": "^1.0.0",
+                "hhvm/systemlib-extractor": "~1.0",
+                "phpunit/phpunit": "~5.1"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ],
+                "files": [
+                    "autoload_files.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Find definitions in PHP or Hack files. Useful for autoloaders.",
+            "homepage": "https://github.com/hhvm/definitions-finder",
+            "keywords": [
+                "autoload",
+                "definitions",
+                "hack",
+                "hhvm"
+            ],
+            "time": "2018-06-28T19:37:43+00:00"
+        },
+        {
+            "name": "facebook/fbexpect",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hhvm/fbexpect.git",
+                "reference": "5671bb1c7335b26de35a8049a680a8bad44c8b99"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhvm/fbexpect/zipball/5671bb1c7335b26de35a8049a680a8bad44c8b99",
+                "reference": "5671bb1c7335b26de35a8049a680a8bad44c8b99",
                 "shasum": ""
             },
             "require": {
@@ -231,20 +282,233 @@
                 "MIT"
             ],
             "description": "Unit test helpers for Facebook projects",
-            "time": "2018-05-09T17:30:06+00:00"
+            "time": "2018-06-11T22:04:56+00:00"
         },
         {
-            "name": "myclabs/deep-copy",
-            "version": "1.8.0",
+            "name": "facebook/fbmarkdown",
+            "version": "v1.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "478465659fd987669df0bd8a9bf22a8710e5f1b6"
+                "url": "https://github.com/hhvm/fbmarkdown.git",
+                "reference": "c5f64b57ce15509da665056b5a41b51dfaa3cad6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/478465659fd987669df0bd8a9bf22a8710e5f1b6",
-                "reference": "478465659fd987669df0bd8a9bf22a8710e5f1b6",
+                "url": "https://api.github.com/repos/hhvm/fbmarkdown/zipball/c5f64b57ce15509da665056b5a41b51dfaa3cad6",
+                "reference": "c5f64b57ce15509da665056b5a41b51dfaa3cad6",
+                "shasum": ""
+            },
+            "require": {
+                "hhvm/hhvm-autoload": "^1.5",
+                "hhvm/hsl": "^1.1|^3.26.0",
+                "hhvm/type-assert": "^3.1"
+            },
+            "require-dev": {
+                "91carriage/phpunit-hhi": "~5.7",
+                "facebook/fbexpect": "^0.4.0|^3.26.0",
+                "hhvm/hhast": "^1.0|^3.26.0",
+                "phpunit/phpunit": "~5.7"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Markdown parser and renderer for Hack",
+            "keywords": [
+                "facebook",
+                "gfm",
+                "hack",
+                "markdown"
+            ],
+            "time": "2018-06-12T22:07:37+00:00"
+        },
+        {
+            "name": "facebook/hh-apidoc",
+            "version": "v0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hhvm/hh-apidoc.git",
+                "reference": "10f05bf1d36990e4d7ef2fb7b7f344df1e3c9b5f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhvm/hh-apidoc/zipball/10f05bf1d36990e4d7ef2fb7b7f344df1e3c9b5f",
+                "reference": "10f05bf1d36990e4d7ef2fb7b7f344df1e3c9b5f",
+                "shasum": ""
+            },
+            "require": {
+                "facebook/definition-finder": "^2.0.0",
+                "facebook/fbmarkdown": "^1.0",
+                "facebook/hh-clilib": "^1.0.0",
+                "hhvm": "^3.27.0",
+                "hhvm/hhast": "^3.26.0",
+                "hhvm/hsl": "^1.4|^3.26.0"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "time": "2018-06-29T16:31:51+00:00"
+        },
+        {
+            "name": "facebook/hh-clilib",
+            "version": "v1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hhvm/hh-clilib.git",
+                "reference": "2772c82a8f5fc715d5a2fbe801563f36fdda9943"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhvm/hh-clilib/zipball/2772c82a8f5fc715d5a2fbe801563f36fdda9943",
+                "reference": "2772c82a8f5fc715d5a2fbe801563f36fdda9943",
+                "shasum": ""
+            },
+            "require": {
+                "hhvm/hsl": "^3.26",
+                "hhvm/type-assert": "^3.2"
+            },
+            "require-dev": {
+                "91carriage/phpunit-hhi": "^5.7",
+                "facebook/fbexpect": "^1.1.0",
+                "hhvm/hhast": "^3.27.0",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "time": "2018-06-20T03:25:12+00:00"
+        },
+        {
+            "name": "hhvm/hacktest",
+            "version": "v0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hhvm/hacktest.git",
+                "reference": "483864c3def16eb4a5162086e2b59b301c69d2a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhvm/hacktest/zipball/483864c3def16eb4a5162086e2b59b301c69d2a9",
+                "reference": "483864c3def16eb4a5162086e2b59b301c69d2a9",
+                "shasum": ""
+            },
+            "require": {
+                "facebook/definition-finder": "^2.0",
+                "facebook/hh-apidoc": "^0.1",
+                "facebook/hh-clilib": "^1.0",
+                "hhvm": "^3.27.0",
+                "hhvm/hhvm-autoload": "^1.6",
+                "hhvm/hsl": "^3.26",
+                "hhvm/type-assert": "^3.2"
+            },
+            "require-dev": {
+                "91carriage/phpunit-hhi": "^5.7",
+                "facebook/fbexpect": "^1.0.0",
+                "hhvm/hhast": "^3.27",
+                "phpunit/phpunit": "^5.7"
+            },
+            "bin": [
+                "bin/hacktest"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Hack Test Library",
+            "time": "2018-07-18T17:07:07+00:00"
+        },
+        {
+            "name": "hhvm/hhast",
+            "version": "v3.27.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hhvm/hhast.git",
+                "reference": "8cd58881ccecaf81a0c330dd204f4e0089ef9104"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhvm/hhast/zipball/8cd58881ccecaf81a0c330dd204f4e0089ef9104",
+                "reference": "8cd58881ccecaf81a0c330dd204f4e0089ef9104",
+                "shasum": ""
+            },
+            "require": {
+                "facebook/hh-clilib": "^1.1.1",
+                "hhvm": "^3.26.0",
+                "hhvm/hsl": "^1.0.0|^3.26.0",
+                "hhvm/type-assert": "^3.1"
+            },
+            "require-dev": {
+                "91carriage/phpunit-hhi": "^5.7",
+                "facebook/fbexpect": "^1.1.0",
+                "facebook/hack-codegen": "~3.0.3",
+                "hhvm/hhvm-autoload": "^1.5",
+                "phpunit/phpunit": "^5.7"
+            },
+            "bin": [
+                "bin/hhast-lint",
+                "bin/hhast-inspect"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "time": "2018-06-28T15:01:11+00:00"
+        },
+        {
+            "name": "hhvm/type-assert",
+            "version": "v3.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hhvm/type-assert.git",
+                "reference": "9bbe7cac2ff831142d74203479e72046cbc932f8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhvm/type-assert/zipball/9bbe7cac2ff831142d74203479e72046cbc932f8",
+                "reference": "9bbe7cac2ff831142d74203479e72046cbc932f8",
+                "shasum": ""
+            },
+            "require": {
+                "hhvm": "^3.23.0",
+                "hhvm/hhvm-autoload": "^1.4",
+                "hhvm/hsl": "^1.0|^3.26.0"
+            },
+            "require-dev": {
+                "91carriage/phpunit-hhi": "~5.1",
+                "facebook/fbexpect": "^0.4.0|^1.0.0",
+                "phpunit/phpunit": "~5.1"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Convert untyped data to typed data",
+            "keywords": [
+                "TypeAssert",
+                "hack"
+            ],
+            "time": "2018-05-09T18:23:07+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
+                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
                 "shasum": ""
             },
             "require": {
@@ -279,7 +543,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2018-05-29T17:25:09+00:00"
+            "time": "2018-06-11T23:09:50+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1456,7 +1720,7 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.1.0",
+            "version": "v4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",

--- a/tests/c/CAsyncTest.php
+++ b/tests/c/CAsyncTest.php
@@ -10,12 +10,13 @@
 
 use namespace HH\Lib\C as C;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 // @oss-disable: use InvariantViolationException as InvariantException;
 
 /**
  * @emails oncall+hack
  */
-final class CAsyncTest extends PHPUnit_Framework_TestCase {
+final class CAsyncTest extends HackTestCase {
 
   public static function provideTestGenFirst(): varray<mixed> {
     return varray[

--- a/tests/c/CIntrospectTest.php
+++ b/tests/c/CIntrospectTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\C;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class CIntrospectTest extends PHPUnit_Framework_TestCase {
+final class CIntrospectTest extends HackTestCase {
 
   public static function provideTestAny(): varray<mixed> {
     return varray[

--- a/tests/c/CReduceTest.php
+++ b/tests/c/CReduceTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\C;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class CReduceTest extends PHPUnit_Framework_TestCase {
+final class CReduceTest extends HackTestCase {
 
   public static function provideTestReduce(): varray<mixed> {
     return varray[
@@ -48,7 +49,7 @@ final class CReduceTest extends PHPUnit_Framework_TestCase {
     Ta $initial,
     Ta $expected,
   ): void {
-    expect(C\reduce($traversable, $accumulator, $initial))->toEqual($expected);
+    expect(C\reduce($traversable, $accumulator, $initial))->toBePHPEqual($expected);
   }
 
   public static function provideTestReduceWithKey(): varray<mixed> {

--- a/tests/c/CSelectTest.php
+++ b/tests/c/CSelectTest.php
@@ -10,12 +10,13 @@
 
 use namespace HH\Lib\C;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 // @oss-disable: use InvariantViolationException as InvariantException;
 
 /**
  * @emails oncall+hack
  */
-final class CSelectTest extends PHPUnit_Framework_TestCase {
+final class CSelectTest extends HackTestCase {
 
   public static function provideTestFind(): varray<mixed> {
     return varray[

--- a/tests/dict/DictAsyncTest.php
+++ b/tests/dict/DictAsyncTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Dict;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class DictAsyncTest extends PHPUnit_Framework_TestCase {
+final class DictAsyncTest extends HackTestCase {
 
   public static function provideTestGen(): varray<mixed> {
     return varray[
@@ -120,7 +121,7 @@ final class DictAsyncTest extends PHPUnit_Framework_TestCase {
         },
       );
       expect($actual)->toBeSame(dict[1 => 1, 2 => 2]);
-      expect($run_cnt['value'])->toEqual(2);
+      expect($run_cnt['value'])->toBeSame(2);
     });
   }
 

--- a/tests/dict/DictCombineTest.php
+++ b/tests/dict/DictCombineTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Dict;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class DictCombineTest extends PHPUnit_Framework_TestCase {
+final class DictCombineTest extends HackTestCase {
 
   public static function provideTestAssociate(): varray<mixed> {
     return varray[

--- a/tests/dict/DictDivideTest.php
+++ b/tests/dict/DictDivideTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Dict;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class DictDivideTest extends PHPUnit_Framework_TestCase {
+final class DictDivideTest extends HackTestCase {
 
   public static function providePartition(): varray<mixed> {
     return varray[

--- a/tests/dict/DictIntrospectTest.php
+++ b/tests/dict/DictIntrospectTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Dict;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class DictIntrospectTest extends PHPUnit_Framework_TestCase {
+final class DictIntrospectTest extends HackTestCase {
 
   public static function provideTestEqual(): varray<mixed> {
     return varray[

--- a/tests/dict/DictOrderTest.php
+++ b/tests/dict/DictOrderTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Dict;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class DictOrderTest extends PHPUnit_Framework_TestCase {
+final class DictOrderTest extends HackTestCase {
 
   public static function provideTestReverse(): varray<mixed> {
     return varray[

--- a/tests/dict/DictSelectTest.php
+++ b/tests/dict/DictSelectTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\{Dict, Str};
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class DictSelectTest extends PHPUnit_Framework_TestCase {
+final class DictSelectTest extends HackTestCase {
 
   public static function provideTestDiffByKey(): varray<mixed> {
     return varray[

--- a/tests/dict/DictTransformTest.php
+++ b/tests/dict/DictTransformTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\{Dict, Str};
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class DictTransformTest extends PHPUnit_Framework_TestCase {
+final class DictTransformTest extends HackTestCase {
 
   public static function provideTestChunk(): varray<mixed> {
     return varray[

--- a/tests/keyset/KeysetAsyncTest.php
+++ b/tests/keyset/KeysetAsyncTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Keyset;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class KeysetAsyncTest extends PHPUnit_Framework_TestCase {
+final class KeysetAsyncTest extends HackTestCase {
 
   public static function provideTestGen(): varray<mixed> {
     return varray[

--- a/tests/keyset/KeysetCombineTest.php
+++ b/tests/keyset/KeysetCombineTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Keyset;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class KeysetCombineTest extends PHPUnit_Framework_TestCase {
+final class KeysetCombineTest extends HackTestCase {
 
   public static function provideTestUnion(): varray<mixed> {
     return varray[

--- a/tests/keyset/KeysetDivideTest.php
+++ b/tests/keyset/KeysetDivideTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Keyset;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class KeysetDivideTest extends PHPUnit_Framework_TestCase {
+final class KeysetDivideTest extends HackTestCase {
 
   public static function providePartition(): varray<mixed> {
     return varray[

--- a/tests/keyset/KeysetIntrospectTest.php
+++ b/tests/keyset/KeysetIntrospectTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Keyset;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class KeysetIntrospectTest extends PHPUnit_Framework_TestCase {
+final class KeysetIntrospectTest extends HackTestCase {
 
   public static function provideTestEqual(): varray<mixed> {
     return varray[

--- a/tests/keyset/KeysetOrderTest.php
+++ b/tests/keyset/KeysetOrderTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Keyset;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class KeysetOrderTest extends PHPUnit_Framework_TestCase {
+final class KeysetOrderTest extends HackTestCase {
 
   public static function provideSort(): varray<mixed> {
     return varray[

--- a/tests/keyset/KeysetSelectTest.php
+++ b/tests/keyset/KeysetSelectTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\{Keyset, Str};
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class KeysetSelectTest extends PHPUnit_Framework_TestCase {
+final class KeysetSelectTest extends HackTestCase {
 
   public static function provideTestDiff(): varray<mixed> {
     return varray[

--- a/tests/keyset/KeysetTransformTest.php
+++ b/tests/keyset/KeysetTransformTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Keyset;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class KeysetTransformTest extends PHPUnit_Framework_TestCase {
+final class KeysetTransformTest extends HackTestCase {
 
   public static function provideTestChunk(): varray<mixed> {
     return varray[

--- a/tests/math/MathCompareTest.php
+++ b/tests/math/MathCompareTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Math;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class MathCompareTest extends PHPUnit_Framework_TestCase {
+final class MathCompareTest extends HackTestCase {
 
   public static function provideTestMaxva(): varray<mixed> {
     return varray[

--- a/tests/math/MathComputeTest.php
+++ b/tests/math/MathComputeTest.php
@@ -11,6 +11,7 @@
 use namespace HH\Lib\{Math, Str};
 use const HH\Lib\_Private\ALPHABET_ALPHANUMERIC;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 // @oss-disable: use InvariantViolationException as InvariantException;
 
 // FB likes to be explicit about md5() being unsuitable for crypto, and
@@ -20,7 +21,7 @@ use function md5 as non_crypto_md5;
 /**
  * @emails oncall+hack
  */
-final class MathComputeTest extends PHPUnit_Framework_TestCase {
+final class MathComputeTest extends HackTestCase {
   public static function provideTestAbs(): varray<mixed> {
     return varray[
       tuple(-1, 1),

--- a/tests/math/MathContainersTest.php
+++ b/tests/math/MathContainersTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Math;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class MathContainersTest extends PHPUnit_Framework_TestCase {
+final class MathContainersTest extends HackTestCase {
 
   public static function provideTestMax(): varray<mixed> {
     return varray[

--- a/tests/str/StrCombineTest.php
+++ b/tests/str/StrCombineTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Str;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class StrCombineTest extends PHPUnit_Framework_TestCase {
+final class StrCombineTest extends HackTestCase {
 
   public static function provideJoin(): varray<mixed> {
     $elements = varray['the', 'quick', 'brown', 'fox', 1];

--- a/tests/str/StrDivideTest.php
+++ b/tests/str/StrDivideTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Str;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class StrDivideTest extends PHPUnit_Framework_TestCase {
+final class StrDivideTest extends HackTestCase {
 
   public static function provideChunk(): varray<mixed> {
     return varray[

--- a/tests/str/StrFormatTest.php
+++ b/tests/str/StrFormatTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Str;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class StrFormatTest extends PHPUnit_Framework_TestCase {
+final class StrFormatTest extends HackTestCase {
 
   public static function provideFormat(): varray<mixed> {
     return varray[

--- a/tests/str/StrIntrospectTest.php
+++ b/tests/str/StrIntrospectTest.php
@@ -11,11 +11,12 @@
 use namespace HH\Lib\Str;
 use function Facebook\FBExpect\expect;
 // @oss-disable: use InvariantViolationException as InvariantException;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class StrIntrospectTest extends PHPUnit_Framework_TestCase {
+final class StrIntrospectTest extends HackTestCase {
 
   public static function provideCompare(): varray<mixed> {
     return varray[

--- a/tests/str/StrSelectTest.php
+++ b/tests/str/StrSelectTest.php
@@ -11,11 +11,12 @@
 use namespace HH\Lib\Str;
 use function Facebook\FBExpect\expect;
 // @oss-disable: use InvariantViolationException as InvariantException;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class StrSelectTest extends PHPUnit_Framework_TestCase {
+final class StrSelectTest extends HackTestCase {
 
   public static function provideSlice(): varray<mixed> {
     return varray[

--- a/tests/str/StrTransformTest.php
+++ b/tests/str/StrTransformTest.php
@@ -11,11 +11,12 @@
 use namespace HH\Lib\Str;
 use function Facebook\FBExpect\expect;
 // @oss-disable: use InvariantViolationException as InvariantException;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class StrTransformTest extends PHPUnit_Framework_TestCase {
+final class StrTransformTest extends HackTestCase {
 
   public static function provideCapitalize(): varray<mixed> {
     return varray[

--- a/tests/tuple/TupleAsyncTest.php
+++ b/tests/tuple/TupleAsyncTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Tuple as Tuple;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class TupleAsyncTest extends PHPUnit_Framework_TestCase {
+final class TupleAsyncTest extends HackTestCase {
   public function testWithNonNullableTypes(): void {
     /* HH_IGNORE_ERROR[5542] open source */
     \HH\Asio\join(async {

--- a/tests/vec/VecAsyncTest.php
+++ b/tests/vec/VecAsyncTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Vec;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class VecAsyncTest extends PHPUnit_Framework_TestCase {
+final class VecAsyncTest extends HackTestCase {
 
   public static function provideTestGen(): varray<mixed> {
     return varray[

--- a/tests/vec/VecCombineTest.php
+++ b/tests/vec/VecCombineTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Vec;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class VecCombineTest extends PHPUnit_Framework_TestCase {
+final class VecCombineTest extends HackTestCase {
 
   public static function provideTestConcat(): varray<mixed> {
     return varray[

--- a/tests/vec/VecDivideTest.php
+++ b/tests/vec/VecDivideTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\Vec;
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class VecDivideTest extends PHPUnit_Framework_TestCase {
+final class VecDivideTest extends HackTestCase {
 
   public static function providePartition(): varray<mixed> {
     return varray[

--- a/tests/vec/VecOrderTest.php
+++ b/tests/vec/VecOrderTest.php
@@ -10,12 +10,13 @@
 
 use namespace HH\Lib\{C, Math, Str, Vec};
 use function \Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 // @oss-disable: use InvariantViolationException as InvariantException;
 
 /**
  * @emails oncall+hack
  */
-final class VecOrderTest extends PHPUnit_Framework_TestCase {
+final class VecOrderTest extends HackTestCase {
 
   public static function provideTestRange(): varray<mixed> {
     return varray[

--- a/tests/vec/VecSelectTest.php
+++ b/tests/vec/VecSelectTest.php
@@ -10,11 +10,12 @@
 
 use namespace HH\Lib\{C, Math, Str, Vec};
 use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class VecSelectTest extends PHPUnit_Framework_TestCase {
+final class VecSelectTest extends HackTestCase {
 
   public static function provideTestDiff(): varray<mixed> {
     return varray[

--- a/tests/vec/VecTransformTest.php
+++ b/tests/vec/VecTransformTest.php
@@ -11,11 +11,12 @@
 use namespace HH\Lib\Vec;
 use function Facebook\FBExpect\expect;
 // @oss-disable: use InvariantViolationException as InvariantException;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
 
 /**
  * @emails oncall+hack
  */
-final class VecTransformTest extends PHPUnit_Framework_TestCase {
+final class VecTransformTest extends HackTestCase {
 
   public static function provideTestChunk(): varray<mixed> {
     return varray[


### PR DESCRIPTION
Summary: Refactor HSL tests to use HackTestCase.
Reviewed By: kmeht

Differential Revision: D8921352
