### PR TITLE
Make it so that INT64_MIN is always a negative integer

### DIFF
--- a/src/math/constants.php
+++ b/src/math/constants.php
@@ -11,7 +11,11 @@
 namespace HH\Lib\Math;
 
 const int INT64_MAX = 9223372036854775807;
-const int INT64_MIN = INT64_MAX + 1; // -9223372036854775808
+// - can't directly represent this as -x is a unary op on x, not a negative
+//   literal
+// - can't use (INT64_MAX + 1) as ints currently overly to float in external
+//   builds for PHP compatibility
+const int INT64_MIN = -1 << 63;
 const int INT53_MAX = 9007199254740992;
 const int INT53_MIN = -9007199254740993;
 const int INT32_MAX = 2147483647;

--- a/tests/dict/DictDivideTest.php
+++ b/tests/dict/DictDivideTest.php
@@ -8,7 +8,7 @@
  *
  */
 
-use namespace HH\Lib\Dict;
+use namespace HH\Lib\{Dict, Vec};
 use function Facebook\FBExpect\expect;
 use type Facebook\HackTest\HackTestCase; // @oss-enable
 

--- a/tests/math/MathConstantsTest.php
+++ b/tests/math/MathConstantsTest.php
@@ -1,0 +1,25 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+use namespace HH\Lib\Math;
+use function Facebook\FBExpect\expect;
+use type Facebook\HackTest\HackTestCase; // @oss-enable
+// @oss-disable: use InvariantViolationException as InvariantException;
+
+/**
+ * @emails oncall+hack
+ */
+final class MathConstantsTest extends HackTestCase {
+  public function testInt64Min(): void {
+    expect(Math\INT64_MIN)->toBeLessThan(0);
+    $less = Math\INT64_MIN- 1;
+    expect($less === Math\INT64_MAX || $less is float)->toBeTrue();
+  }
+}


### PR DESCRIPTION
- Explanation in comments
- Added missing namespace import from divide test to get clean
typechecker run

fixes #55