### PR TITLE
add `HH\Lib\Dict\union`

### DIFF
--- a/src/dict/combine.php
+++ b/src/dict/combine.php
@@ -52,3 +52,21 @@ function merge<Tk as arraykey, Tv>(
   }
   return $result;
 }
+
+/*
+ * Merge multiple KeyedTraversables into a new dict. In the case of duplicate
+ * keys, the value will be ignored.
+ */
+function union<Tk as arraykey, Tv>(
+  KeyedTraversable<Tk, Tv> ...$traversables
+): dict<Tk, Tv> {
+  $result = dict[];
+  foreach ($traversables as $traversable) {
+    foreach ($traversable as $key => $value) {
+        if (!C\contains_key($result, $key)) {
+            $result[$key] = $value;
+        }
+    }
+  }
+  return $result;
+}

--- a/tests/dict/DictCombineTest.php
+++ b/tests/dict/DictCombineTest.php
@@ -126,4 +126,41 @@ final class DictCombineTest extends HackTest {
   ): void {
     expect(Dict\merge($first, ...$rest))->toBeSame($expected);
   }
+  
+  public static function provideTestUnion(): varray<mixed> {
+    return varray[
+      tuple(
+        vec[
+          Map {'a' => 'apple', 'b' => 'banana'},
+          dict['a' => 'pear', 'b' => 'strawberry', 'c' => 'cherry'],
+          darray['c' => 'chocolat']
+        ],
+        dict[ 'a' => 'apple', 'b' => 'banana', 'c' => 'cherry']
+      ),
+      tuple(
+        vec[
+          dict['a' => 'pear', 'b' => 'strawberry', 'c' => 'cherry'],
+          Map {'a' => 'apple', 'b' => 'banana'},
+          darray['c' => 'chocolat']
+        ],
+        dict[ 'a' => 'pear', 'b' => 'strawberry', 'c' => 'cherry']
+      ),
+      tuple(
+        vec[
+          darray['c' => 'chocolat']
+          dict['a' => 'pear', 'b' => 'strawberry', 'c' => 'cherry'],
+          Map {'a' => 'apple', 'b' => 'banana'},
+        ],
+        dict[ 'a' => 'pear', 'b' => 'strawberry', 'c' => 'chocolat']
+      ),
+    ];
+  }
+  
+  <<DataProvider('provideTestUnion')>>
+  public function testUnion<Tk as arraykey, Tv>(
+    Container<KeyedTraversable<Tk, Tv>> $traversables,
+    dict<Tk, Tv> $exprected
+  ): void {
+    expect(Dict\union(...$traversables))->toBeSame($expected); 
+  }
 }


### PR DESCRIPTION
just like PHPs `+` operator on arrays, this functions allows appending `KeyedTraversable`s into a new dict without overriding the values in case of duplicated keys unlike `HH\Lib\Dict\merge`.

reference : https://secure.php.net/manual/en/language.operators.array.php

example : 

```hack
<?hh

use namespace HH\Lib\Dict;

$a = dict[
    'a' => 'apple',
    'b' => 'banana'
];

$b = dict[
    'a' => 'pear', 
    'b' => 'strawberry', 
    'c' => 'cherry'
];

$c = Dict\merge($a, $b);
// $c = dict['a' => 'pear', 'b' => 'strawberry', 'c' => 'cherry'];

/* $d = $a + $b; */
$d = Dict\union($a, $b);
// $d = dict[ 'a' => 'apple', 'b' => 'banana', 'c' => 'cherry' ];
```