### PR TITLE
Add a time-safe string equality function

### DIFF
--- a/src/str/introspect.php
+++ b/src/str/introspect.php
@@ -284,3 +284,19 @@ function starts_with_ci(
   /* HH_IGNORE_ERROR[4107] __PHPStdLib */
   return \strncasecmp($string, $prefix, length($prefix)) === 0;
 }
+
+/**
+ * Returns whether the two strings are equal in a time-safe manner.
+ *
+ * The run time of this function is dependent only on the length of the
+ * second argument.
+ */
+<<__Rx>>
+function timesafe_equals(
+  string $known,
+  string $user,
+): bool {
+  /* HH_IGNORE_ERROR[2049] __PHPStdLib */
+  /* HH_IGNORE_ERROR[4107] __PHPStdLib */
+  return \hash_equals($known, $user);
+}

--- a/tests/str/StrIntrospectTest.php
+++ b/tests/str/StrIntrospectTest.php
@@ -432,4 +432,23 @@ final class StrIntrospectTest extends HackTest {
     expect(Str\starts_with_ci($string, $prefix))->toBeSame($expected);
   }
 
+
+  public static function provideTimesafeEquals(): varray<mixed> {
+    return varray[
+      tuple('foo', 'foo', true),
+      tuple('foo', 'Foo', false),
+      tuple('Foo', 'foo', false),
+      tuple('fo', 'foo', false),
+      tuple('foo', 'fo', false),
+    ];
+  }
+
+  <<DataProvider('provideTimesafeEquals')>>
+  public function testTimesafeEquals(
+    string $known,
+    string $user,
+    bool $expected,
+  ): void {
+    expect(Str\timesafe_equals($known, $user))->toBeSame($expected);
+  }
 }


### PR DESCRIPTION
Provides a HSL wrapper for \hash_equals for time-safe equality.

Am kinda expecting the name to need changing.

This is highly likely to need to always call out to C++ so that the JIT doesn't go and optimise out the time-safety.