### PR TITLE
Fix OSS tests, support nightlies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "require-dev": {
-    "facebook/fbexpect": "^2.0.0",
+    "facebook/fbexpect": "^2.5.1",
     "hhvm/hacktest": "^1.0",
     "hhvm/hhvm-autoload": "^2.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "038ab4fe29990569075ee8ef30b81db4",
+    "content-hash": "d137a67539970759b3a44ed929ba54e4",
     "packages": [],
     "packages-dev": [
         {
@@ -44,16 +44,16 @@
         },
         {
             "name": "facebook/fbexpect",
-            "version": "v2.4.0",
+            "version": "v2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/fbexpect.git",
-                "reference": "a0fd5e57c15bc580dd130e3298f01ca51421c189"
+                "reference": "cf8afe9e17c7edb0d5694645ad93b8179d06ec5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/fbexpect/zipball/a0fd5e57c15bc580dd130e3298f01ca51421c189",
-                "reference": "a0fd5e57c15bc580dd130e3298f01ca51421c189",
+                "url": "https://api.github.com/repos/hhvm/fbexpect/zipball/cf8afe9e17c7edb0d5694645ad93b8179d06ec5d",
+                "reference": "cf8afe9e17c7edb0d5694645ad93b8179d06ec5d",
                 "shasum": ""
             },
             "require": {
@@ -63,6 +63,7 @@
                 "hhvm/hsl": "^3.26|^4.0"
             },
             "require-dev": {
+                "hhvm/hhast": "^4.0",
                 "hhvm/hhvm-autoload": "^2.0"
             },
             "type": "library",
@@ -71,7 +72,7 @@
                 "MIT"
             ],
             "description": "Unit test helpers for Facebook projects",
-            "time": "2019-02-08T16:39:19+00:00"
+            "time": "2019-02-14T22:40:45+00:00"
         },
         {
             "name": "facebook/hh-clilib",

--- a/tests/keyset/KeysetTransformTest.php
+++ b/tests/keyset/KeysetTransformTest.php
@@ -228,7 +228,7 @@ final class KeysetTransformTest extends HackTest {
 
   <<DataProvider('provideTestFlatten')>>
   public function testFlatten<Tv as arraykey>(
-    Traversable<Rx\Traversable<Tv>> $traversables,
+    Traversable<\HH\Rx\Traversable<Tv>> $traversables,
     keyset<Tv> $expected,
   ): void {
     expect(Keyset\flatten($traversables))->toBeSame($expected);


### PR DESCRIPTION
- there was a second rx issue
- update composer files to use a newer version of fbexpect that is still
  valid hack with the nightlies