### PR TITLE
Remove usages of lval as an expression.

### DIFF
--- a/src/regex/regex.php
+++ b/src/regex/regex.php
@@ -44,7 +44,11 @@ function every_match<T as Match>(
 ): vec<T> {
   $haystack_length = Str\length($haystack);
   $result = vec[];
-  while ($match = _Private\regex_match($haystack, $pattern, $offset)) {
+  while (true) {
+    $match = _Private\regex_match($haystack, $pattern, $offset);
+    if ($match === null) {
+      break;
+    }
     $captures = $match[0];
     $result[] = $captures;
     $match_begin = $match[1];
@@ -123,7 +127,11 @@ function replace_with<T as Match>(
   $haystack_length = Str\length($haystack);
   $result = Str\slice($haystack, 0, 0);
   $match_end = 0;
-  while ($match = _Private\regex_match($haystack, $pattern, $offset)) {
+  while (true) {
+    $match = _Private\regex_match($haystack, $pattern, $offset);
+    if ($match === null) {
+      break;
+    }
     $captures = $match[0];
     $match_begin = $match[1];
     // Copy anything between the previous match and this one

--- a/src/str/transform.php
+++ b/src/str/transform.php
@@ -245,12 +245,10 @@ function replace_every_ci(
 function reverse(
   string $string,
 ): string {
-  $lo = 0;
-  $hi = namespace\length($string) - 1;
-  while ($lo < $hi) {
+  for ($lo = 0, $hi = namespace\length($string) - 1; $lo < $hi; $lo++, $hi--) {
     $temp = $string[$lo];
-    $string[$lo++] = $string[$hi];
-    $string[$hi--] = $temp;
+    $string[$lo] = $string[$hi];
+    $string[$hi] = $temp;
   }
   return $string;
 }

--- a/src/vec/order.php
+++ b/src/vec/order.php
@@ -50,12 +50,10 @@ function reverse<Tv>(
   Traversable<Tv> $traversable,
 ): vec<Tv> {
   $vec = vec($traversable);
-  $lo = 0;
-  $hi = C\count($vec) - 1;
-  while ($lo < $hi) {
+  for ($lo = 0, $hi = C\count($vec) - 1; $lo < $hi; $lo++, $hi--) {
     $temp = $vec[$lo];
-    $vec[$lo++] = $vec[$hi];
-    $vec[$hi--] = $temp;
+    $vec[$lo] = $vec[$hi];
+    $vec[$hi] = $temp;
   }
   return $vec;
 }


### PR DESCRIPTION
Summary: required for .hhconfig disable_lval_as_an_expression.

Signed-off-by: Arthur Loiret <arthur.loiret@emerton-data.com>