### PR TITLE
`Regex\matches` builds tuples and `Math\is_nan` as alias for `\is_nan`.

### DIFF
--- a/src/math/compare.php
+++ b/src/math/compare.php
@@ -51,3 +51,16 @@ function minva<T as num>(
   }
   return $min;
 }
+
+/**
+ * Returns whether a number has the value NaN.
+ *
+ * When comparing $x === NaN false will be returned
+ * even if $x is NaN.
+ */
+ <<__Rx>>
+ function is_nan(num $num): bool{
+  /* HH_IGNORE_ERROR[2049] __PHPStdLib */
+  /* HH_IGNORE_ERROR[4107] __PHPStdLib */
+  return \is_nan((float)$num);
+ }

--- a/src/regex/regex.php
+++ b/src/regex/regex.php
@@ -173,11 +173,7 @@ function split<T as Match>(
   if ($limit === null) {
     $limit = \INF;
   }
-  invariant(
-    $limit > 1,
-    'Expected limit greater than 1, got %d.',
-    $limit,
-  );
+  invariant($limit > 1, 'Expected limit greater than 1, got %d.', $limit);
   $haystack_length = Str\length($haystack);
   $result = vec[];
   $offset = 0;
@@ -213,8 +209,6 @@ function split<T as Match>(
 /**
  * Renders a Regex Pattern to a string.
  */
-function to_string<T as Match>(
-  Pattern<T> $pattern,
-): string {
+function to_string<T as Match>(Pattern<T> $pattern): string {
   return $pattern as string;
 }

--- a/src/regex/regex.php
+++ b/src/regex/regex.php
@@ -77,7 +77,24 @@ function matches<T as Match>(
   Pattern<T> $pattern,
   int $offset = 0,
 ): bool {
-  return _Private\regex_match($haystack, $pattern, $offset) !== null;
+  _Private\validate_offset($offset, Str\length($haystack));
+  $match = darray[];
+  /* HH_IGNORE_ERROR[2049] __PHPStdLib */
+  /* HH_IGNORE_ERROR[4107] __PHPStdLib */
+  $status = @\preg_match(
+    /* HH_IGNORE_ERROR[4110] */ $pattern,
+    $haystack,
+    &$match,
+    /* HH_IGNORE_ERROR[2049] Private constant */
+    /* HH_IGNORE_ERROR[4106] Private constant */
+    \PREG_FB__PRIVATE__HSL_IMPL |
+      \PREG_OFFSET_CAPTURE,
+    $offset,
+  );
+  if ($status is int) {
+    return (bool)$status;
+  }
+  throw new Exception($pattern);
 }
 
 /**


### PR DESCRIPTION
Regex\matches previously asserted that the return of _Private\regex_match was nonnull. We are spending cpu time building the return value of _Private\regex_match and not looking at its value, but merely at its type. This _may_ perform better, because we don't bother building that returned tuple.