### PR TITLE
Make the `float` formatters take a `num` instead.

### DIFF
--- a/src/str/format.php
+++ b/src/str/format.php
@@ -19,11 +19,11 @@ interface SprintfFormat {
   public function format_u(int $s): string;
   public function format_b(int $s): string; // bit strings
   // Technically %f is locale-dependent (and thus wrong)
-  public function format_f(float $s): string;
-  public function format_g(float $s): string;
-  public function format_upcase_f(float $s): string;
-  public function format_e(float $s): string;
-  public function format_upcase_e(float $s): string;
+  public function format_f(num $s): string;
+  public function format_g(num $s): string;
+  public function format_upcase_f(num $s): string;
+  public function format_e(num $s): string;
+  public function format_upcase_e(num $s): string;
   public function format_x(int $s): string;
   public function format_o(int $s): string;
   public function format_c(int $s): string;


### PR DESCRIPTION
As @jjergus addressed in the case of [PlainSprintf](/facebook/hhvm/pull/8575#issuecomment-536642020) you can safely pass an int to these formatters. This is favorable over a `Str\format('Power level: %f', (float)$num)`, since the float cast will hide the typeerror in the case that `$num` would not be a number. At runtime it would silently convert `string(9) "Over 9000"` to `float(0.0)`.