### PR TITLE
dev-depend on hsl-experimental master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
   "require-dev": {
     "facebook/fbexpect": "^2.5.1",
     "hhvm/hacktest": "^1.0",
-    "hhvm/hhvm-autoload": "^2.0"
+    "hhvm/hhvm-autoload": "^2.0",
+    "hhvm/hsl-experimental": "dev-master"
   },
   "require": {
     "hhvm": "^4.18"


### PR DESCRIPTION
In general we shouldn't be depending on hsl-experimental - but hacktest
does because hh-clilib uses the IO.

Real fix for this is to move IO out of experimental ASAP, but we want
sockets done first.