### PR TITLE
Re-sync with internal repository

### DIFF
--- a/src/Ref.php
+++ b/src/Ref.php
@@ -14,7 +14,7 @@ namespace HH\Lib;
  *
  * This is especially useful for mutating values outside of a lambda's scope.
  *
- * In eralAsync, it's preferable to refactor to use return values or `inout`
+ * In general, it's preferable to refactor to use return values or `inout`
  * parameters instead of using this class - however, a `Ref` of a Hack array
  * is generally preferable to a Hack collection - e.g. prefer `Ref<vec<T>>`
  * over `Vector<T>`.

--- a/src/private.php
+++ b/src/private.php
@@ -66,7 +66,7 @@ function tuple_from_vec(mixed $x): mixed {
 const string ALPHABET_ALPHANUMERIC =
   '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
-async function wAsync<T>(
+async function genw<T>(
   Awaitable<T> $gen,
 ): Awaitable<ResultOrExceptionWrapper<T>> {
   try {


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.