### PR TITLE
Mark uppercase as __Rx

### DIFF
--- a/src/str/transform.php
+++ b/src/str/transform.php
@@ -297,11 +297,12 @@ function to_int(
 /**
  * Returns the string with all alphabetic characters converted to uppercase.
  */
-<<__RxLocal>>
+<<__Rx>>
 function uppercase(
   string $string,
 ): string {
   /* HH_FIXME[2049] calling stdlib directly */
   /* HH_FIXME[4107] calling stdlib directly */
+  /* HH_FIXME[4200] Rx calling non-rx */
   return \strtoupper($string);
 }


### PR DESCRIPTION
It was `__RxLocal` before, for a reason that no longer holds.

This has an impact on non-FB usage: in the case a function contributed to the HSL would need to call `uppercase`, it couldn't be marked `__Rx` without a `HH_FIXME[4200]`.