### PR TITLE
Attempt to fix the composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "The Hack Standard Library",
   "extra": {
     "branch-alias": {
-      "dev-master": "3.x-dev"
+      "dev-master": "3.30.x-dev"
     }
   },
   "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
   "description": "The Hack Standard Library",
   "extra": {
     "branch-alias": {
-      "dev-master": "3.30.x-dev"
+      "dev-master": "3.30.x-dev",
+      "dev-v3.30.x": "3.30.x-dev"
     }
   },
   "license": "MIT",


### PR DESCRIPTION
Composer isn't happy with installing HackTest, since that requires the HSL, which requires HackTest.
There must be some way of aliasing this that Fred referred to, but it appears it was already doing that.
Maybe we weren't specific enough?

https://github.com/hhvm/hsl/pull/121#issuecomment-579368800

> Still failing; I think this is the compsoer.json branch configuration - for example, we have this in master:
> 
> ```
> 	  "extra": {
>     "branch-alias": {
>       "dev-master": "4.x-dev"
>     }
>   },
> ```