### PR TITLE
Be explicit with what program to run composer with

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -2,7 +2,7 @@
 set -ex
 hhvm --version
 
-composer install
+hhvm composer install
 
 hh_client
 


### PR DESCRIPTION
It almost can't have been running with php, since that usually results in fatal error when building the autoloader.

It this isn't it, I don't know why composer doesn't want to install.
It works fine in the PR travis, but the branch travis keeps failing at composer install.
I don't know what else I can do, since I can make this error happen locally either.