### PR TITLE
Add Vec\zip() to the HSL

### DIFF
--- a/src/vec/combine.php
+++ b/src/vec/combine.php
@@ -10,6 +10,8 @@
 
 namespace HH\Lib\Vec;
 
+use namespace HH\Lib\{C, Math};
+
 /**
  * Returns a new vec formed by concatenating the given Traversables together.
  *
@@ -30,6 +32,34 @@ function concat<Tv>(
     foreach ($traversable as $value) {
       $result[] = $value;
     }
+  }
+  return $result;
+}
+
+/**
+ * Returns a new vec formed creating a tuple of the nth element of both Traversables.
+ *
+ * If the Traversables are not of equal length, the result will have
+ * the same number of elements as the shortest Traversable.
+ * Elements of the longer Traversable after the length of the shorter one
+ * will be ignored.
+ *
+ * Time complexity: O(min(m, n)), where m is the size of `$first` and n is the
+ * size of `$second`
+ * Space complexity: O(min(m, n)), where m is the size of `$first` and n is the
+ * size of `$second`
+ */
+<<__Rx, __AtMostRxAsArgs>>
+function zip<T1, T2>(
+  <<__OnlyRxIfImpl(\HH\Rx\Traversable::class)>> Traversable<T1> $first,
+  <<__OnlyRxIfImpl(\HH\Rx\Traversable::class)>> Traversable<T2> $second,
+): vec<(T1, T2)> {
+  $one = vec($first);
+  $two = vec($second);
+  $result = vec[];
+  $lesser_count = Math\minva(C\count($one), C\count($two));
+  for ($i = 0; $i < $lesser_count; ++$i) {
+    $result[] = tuple($one[$i], $two[$i]);
   }
   return $result;
 }

--- a/src/vec/combine.php
+++ b/src/vec/combine.php
@@ -22,8 +22,7 @@ namespace HH\Lib\Vec;
  */
 <<__Rx, __AtMostRxAsArgs>>
 function concat<Tv>(
-  <<__OnlyRxIfImpl(\HH\Rx\Traversable::class)>>
-  Traversable<Tv> $first,
+  <<__OnlyRxIfImpl(\HH\Rx\Traversable::class)>> Traversable<Tv> $first,
   Container<Tv> ...$rest
 ): vec<Tv> {
   $result = vec($first);

--- a/tests/vec/VecCombineTest.php
+++ b/tests/vec/VecCombineTest.php
@@ -50,4 +50,59 @@ final class VecCombineTest extends HackTest {
     expect(Vec\concat($first, ...$rest))->toEqual($expected);
   }
 
+  public static function provideTestZip(
+  ): dict<
+    string,
+    (Traversable<mixed>, Traversable<mixed>, Traversable<(mixed, mixed)>),
+  > {
+    return dict[
+      'empty' => tuple(dict[], vec[], vec[]),
+      'one element' => tuple(vec['a'], dict[0 => 'b'], vec[tuple('a', 'b')]),
+      'first is longer than second' =>
+        tuple(vec[1, -1], vec[2], vec[tuple(1, 2)]),
+      'second is longer than first' =>
+        tuple(vec['yes'], vec['maybe', 'no'], vec[tuple('yes', 'maybe')]),
+      'very long input' => tuple(
+        Vec\range(0, 101),
+        Vec\range(0, 101),
+        Vec\map(Vec\range(0, 101), (int $i) ==> tuple($i, $i)),
+      ),
+      'Hack Collections' => tuple(
+        Map {'banana' => 5, 'pear' => 4},
+        Set {3, 2},
+        vec[tuple(5, 3), tuple(4, 2)],
+      ),
+      'Generators' => tuple(
+        HackLibTestTraversables::getKeyedIterator(dict[
+          'keys' => 'do',
+          'not' => 'matter',
+          'for' => 'vec',
+          'zip' => 'anyhow',
+        ]),
+        HackLibTestTraversables::getIterator(vec[
+          'generators',
+          'are',
+          'very',
+          'powerful',
+          'indeed',
+        ]),
+        vec[
+          tuple('do', 'generators'),
+          tuple('matter', 'are'),
+          tuple('vec', 'very'),
+          tuple('anyhow', 'powerful'),
+        ],
+      ),
+    ];
+  }
+
+  <<DataProvider('provideTestZip')>>
+  public function testZip<T1, T2>(
+    Traversable<T1> $first,
+    Traversable<T2> $second,
+    Traversable<(T1, T2)> $expected,
+  ): void {
+    expect(Vec\zip($first, $second))->toEqual($expected);
+  }
+
 }


### PR DESCRIPTION
I believe this already exists as `Vec\fb\zip()`.
If the fb impl is different / better somehow, it could also be promoted out of the fb namespace.

I've been using `Vec\Lex\zip()` for months and it is a very useful tool in my toolbox.
I use it in case where I need to iterate over two things at once, but don't want to manipulate raw indexes using a `for($i = 0;...)` loop.

```HACK
$vec1 = vec[...];
$vec2 = vec[...];
foreach(Vec\Lex\zip($vec1, $vec2) as list($one, $two)){
  // code...
}
```

I am making this PR to get the ball rolling on other useful HSL functions.
F.e. `C\fb\pop_back()` and `Vec\gen_map_limited_concurrency()`.

