### PR TITLE
Add C\findx() to the HSL

### DIFF
--- a/src/c/select.php
+++ b/src/c/select.php
@@ -16,6 +16,8 @@ use namespace HH\Lib\{_Private, Str};
  * Returns the first value of the given Traversable for which the predicate
  * returns true, or null if no such value is found.
  *
+ * For cases where you MUST find a value, see `C\findx`.
+ *
  * Time complexity: O(n)
  * Space complexity: O(1)
  */
@@ -32,6 +34,36 @@ function find<T>(
     }
   }
   return null;
+}
+
+/**
+ * Returns the first value of the given Traversable for which the predicate
+ * returns true.
+ * If the predicate does not return true for any elements of the traversable
+ * an InvariantException is thrown.
+ *
+ * If you'd want to return null when non of the elements cause the
+ * predicate to return true, see `C\find`.
+ *
+ * Time complexity: O(n)
+ * Space complexity: O(1)
+ */
+<<__Rx, __AtMostRxAsArgs>>
+function findx<T>(
+  <<__MaybeMutable, __OnlyRxIfImpl(\HH\Rx\Traversable::class)>>
+  Traversable<T> $traversable,
+  <<__AtMostRxAsFunc>>
+  (function(T): bool) $value_predicate,
+): ?T {
+  foreach ($traversable as $value) {
+    if ($value_predicate($value)) {
+      return $value;
+    }
+  }
+  invariant_violation(
+    "%s: Expected to find a value matching the \$value_predicate",
+    __FUNCTION__
+  );
 }
 
 /**

--- a/tests/c/CSelectTest.php
+++ b/tests/c/CSelectTest.php
@@ -45,6 +45,21 @@ final class CSelectTest extends HackTest {
     expect(C\find($traversable, $value_predicate))->toEqual($expected);
   }
 
+  <<DataProvider('provideTestFind')>>
+  public function testFindx<T>(
+    Traversable<T> $traversable,
+    (function(T): bool) $value_predicate,
+    ?T $expected,
+  ): void {
+    if($expected is null){
+      expect(() ==> C\findx($traversable, $value_predicate))->toThrow(
+        InvariantException::class,
+      );
+    } else {
+      expect(C\findx($traversable, $value_predicate))->toEqual($expected);
+    }
+  }
+
   public static function provideTestFindKey(): varray<mixed> {
     return varray[
       tuple(


### PR DESCRIPTION
This is part of the README.md file.

```
Find-like operations that can fail should return ?T;
a second function should be added with an x suffix
that uses an invariant to return T (e.g. C\first(), C\firstx())
```

There is a notable difference between `C\find(...) as nonnull` and `C\findx(...)` in the case where `null` would be a case where the `$value_predicate` returns true. There would be no way to know if you got a `null` returned, because there was a `null` in the `$traversable` or because nothing was found.

If `C\fb\findx()` is different / better than this, it may be promoted instead.