### PR TITLE
Key sorting callbacks can return `num` (#114)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: generic
 services: docker
 env:
-- HHVM_VERSION=4.25-latest
+- HHVM_VERSION=4.41-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
     "hhvm/hsl-experimental": "dev-master"
   },
   "require": {
-    "hhvm": "^4.25"
+    "hhvm": "^4.41"
   }
 }

--- a/src/c/order.php
+++ b/src/c/order.php
@@ -35,7 +35,7 @@ namespace HH\Lib\C;
 function is_sorted<Tv>(
   <<__MaybeMutable, __OnlyRxIfImpl(\HH\Rx\Traversable::class)>>
   Traversable<Tv> $traversable,
-  <<__AtMostRxAsFunc>> ?(function(Tv, Tv): int) $comparator = null,
+  <<__AtMostRxAsFunc>> ?(function(Tv, Tv): num) $comparator = null,
 ): bool {
   $vec = vec($traversable);
   if (is_empty($vec)) {
@@ -82,7 +82,7 @@ function is_sorted_by<Tv, Ts>(
   <<__MaybeMutable, __OnlyRxIfImpl(\HH\Rx\Traversable::class)>>
   Traversable<Tv> $traversable,
   <<__AtMostRxAsFunc>> (function(Tv): Ts) $scalar_func,
-  <<__AtMostRxAsFunc>> ?(function(Ts, Ts): int) $comparator = null,
+  <<__AtMostRxAsFunc>> ?(function(Ts, Ts): num) $comparator = null,
 ): bool {
   $vec = vec($traversable);
   if (is_empty($vec)) {

--- a/src/dict/order.php
+++ b/src/dict/order.php
@@ -63,7 +63,7 @@ function shuffle<Tk as arraykey, Tv>(
 function sort<Tk as arraykey, Tv>(
   <<__MaybeMutable, __OnlyRxIfImpl(\HH\Rx\KeyedTraversable::class)>>
   KeyedTraversable<Tk, Tv> $traversable,
-  <<__AtMostRxAsFunc>> ?(function(Tv, Tv): int) $value_comparator = null,
+  <<__AtMostRxAsFunc>> ?(function(Tv, Tv): num) $value_comparator = null,
 ): dict<Tk, Tv> {
   $result = dict($traversable);
   if ($value_comparator) {
@@ -99,7 +99,7 @@ function sort_by<Tk as arraykey, Tv, Ts>(
   <<__MaybeMutable, __OnlyRxIfImpl(\HH\Rx\KeyedTraversable::class)>>
   KeyedTraversable<Tk, Tv> $traversable,
   <<__AtMostRxAsFunc>> (function(Tv): Ts) $scalar_func,
-  <<__AtMostRxAsFunc>> ?(function(Ts, Ts): int) $scalar_comparator = null,
+  <<__AtMostRxAsFunc>> ?(function(Ts, Ts): num) $scalar_comparator = null,
 ): dict<Tk, Tv> {
   $tuple_comparator = $scalar_comparator
     ? ((Ts, Tv) $a, (Ts, Tv) $b) ==> $scalar_comparator($a[0], $b[0])
@@ -127,7 +127,7 @@ function sort_by<Tk as arraykey, Tv, Ts>(
 function sort_by_key<Tk as arraykey, Tv>(
   <<__MaybeMutable, __OnlyRxIfImpl(\HH\Rx\KeyedTraversable::class)>>
   KeyedTraversable<Tk, Tv> $traversable,
-  <<__AtMostRxAsFunc>> ?(function(Tk, Tk): int) $key_comparator = null,
+  <<__AtMostRxAsFunc>> ?(function(Tk, Tk): num) $key_comparator = null,
 ): dict<Tk, Tv> {
   $result = dict($traversable);
   if ($key_comparator) {

--- a/src/keyset/order.php
+++ b/src/keyset/order.php
@@ -23,7 +23,7 @@ namespace HH\Lib\Keyset;
 function sort<Tv as arraykey>(
   <<__MaybeMutable, __OnlyRxIfImpl(\HH\Rx\Traversable::class)>>
   Traversable<Tv> $traversable,
-  <<__AtMostRxAsFunc>> ?(function(Tv, Tv): int) $comparator = null,
+  <<__AtMostRxAsFunc>> ?(function(Tv, Tv): num) $comparator = null,
 ): keyset<Tv> {
   $keyset = keyset($traversable);
   if ($comparator) {

--- a/src/vec/order.php
+++ b/src/vec/order.php
@@ -91,7 +91,7 @@ function sort<Tv>(
   <<__MaybeMutable, __OnlyRxIfImpl(\HH\Rx\Traversable::class)>>
   Traversable<Tv> $traversable,
   <<__AtMostRxAsFunc>>
-  ?(function(Tv, Tv): int) $comparator = null,
+  ?(function(Tv, Tv): num) $comparator = null,
 ): vec<Tv> {
   $vec = vec($traversable);
   if ($comparator) {
@@ -128,7 +128,7 @@ function sort_by<Tv, Ts>(
   <<__AtMostRxAsFunc>>
   (function(Tv): Ts) $scalar_func,
   <<__AtMostRxAsFunc>>
-  ?(function(Ts, Ts): int) $comparator = null,
+  ?(function(Ts, Ts): num) $comparator = null,
 ): vec<Tv> {
   $vec = vec($traversable);
   $order_by = Dict\map($vec, $scalar_func);


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/hhvm/hsl-experimental/pull/114

Pull Request resolved: https://github.com/hhvm/hsl/pull/118

The various sorting function builtin HHIs have been updated to allow this, and it follows that the HSL could allow this too.

https://github.com/facebook/hhvm/commit/38e220a43694c29e477a902141620df9e7ba798d

Reviewed By: fredemmott

Differential Revision: D19503967

