### PR TITLE
[ Finishing ] Implement replace_every_nonrecursive{,_ci}

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -6,4 +6,4 @@ unsafe_rx = false
 ignored_paths = [ "vendor/.+/tests/.+" ]
 user_attributes=
 allowed_decl_fixme_codes=2053,4045
-allowed_fixme_codes_strict=2011,2049,2050,2053,4027,4045,4106,4108,4110,4128,4135,4188,4200,4240,4248,4297,4323
+allowed_fixme_codes_strict=2011,2049,2050,2053,4027,4045,4106,4107,4108,4110,4128,4135,4188,4200,4240,4248,4297,4323

--- a/src/str/transform.php
+++ b/src/str/transform.php
@@ -282,8 +282,8 @@ function replace_every_nonrecursive(
  *
  * - For having new values searched again, see `Str\replace_every_ci()`.
  *
- * Time complexity O(length * a) where `length` is the length of the subject
- * and a is the amount of replacers with different lengths.
+ * Time complexity O(a + length * b) where a is the sum of all key lengths
+ * and b is the sum of distinct key lengths
  */
 <<__Rx>>
 function replace_every_nonrecursive_ci(

--- a/src/str/transform.php
+++ b/src/str/transform.php
@@ -309,8 +309,7 @@ function replace_every_nonrecursive_ci(
     $replacements_lc[$key_lc] = $value;
   }
 
-  // Sort desc instead of asc
-  $key_lengths = Vec\sort($key_lengths, ($key1, $key2) ==> -($key1 <=> $key2));
+  $key_lengths = Vec\sort($key_lengths) |> Vec\reverse($$);
 
   $output = '';
   for ($pos = 0; $pos < length($haystack); ) {

--- a/src/str/transform.php
+++ b/src/str/transform.php
@@ -275,8 +275,15 @@ function replace_every_nonrecursive(
  *
  * Once a substring has been replaced, its new value will not be searched
  * again.
+ * If a replacer is the prefix of another (like "car" and "carpet"), the longer
+ * one (carpet) gets replaced, if there is any ambiguity.
+ * When two replacers are passed that are identical except for case
+ * an invariant exception is thrown.
  *
  * - For having new values searched again, see `Str\replace_every_ci()`.
+ *
+ * Time complexity O(length * a) where `length` is the length of the subject
+ * and a is the amount of replacers with different lengths.
  */
 <<__Rx>>
 function replace_every_nonrecursive_ci(

--- a/tests/str/StrTransformTest.php
+++ b/tests/str/StrTransformTest.php
@@ -500,16 +500,6 @@ final class StrTransformTest extends HackTest {
       tuple(
         'Hello world',
         dict[
-          'h' => 'H',
-          'H' => 'h',
-          'w' => 'W',
-          'W' => 'w',
-        ],
-        'Hello World',
-      ),
-      tuple(
-        'Hello world',
-        dict[
           'Hello' => 'hi',
           'World' => 'universe',
         ],

--- a/tests/str/StrTransformTest.php
+++ b/tests/str/StrTransformTest.php
@@ -559,7 +559,9 @@ final class StrTransformTest extends HackTest {
 
   public function testReplaceEveryNonrecursiveCIExceptions(): void {
     expect(() ==> Str\replace_every_nonrecursive_ci('hello world', dict['h' => 'H', '' => 'W']))
-      ->toThrow(InvariantException::class);
+      ->toThrow(InvariantException::class, 'empty');
+    expect(() ==> Str\replace_every_nonrecursive_ci('hello world', dict['AbCd' => 'xxx', 'abcd' => 'yyy']))
+      ->toThrow(InvariantException::class, 'Duplicate');
   }
 
   public static function providerReverse(): vec<(string, string)> {

--- a/tests/str/StrTransformTest.php
+++ b/tests/str/StrTransformTest.php
@@ -526,6 +526,8 @@ final class StrTransformTest extends HackTest {
         dict[
           'sub' => 'subject',
           'bject' => 'FAIL',
+          'ject' => 'FAIL',
+          'c' => 'FAIL',
         ],
         'subject fast',
       ),

--- a/tests/str/StrTransformTest.php
+++ b/tests/str/StrTransformTest.php
@@ -338,6 +338,30 @@ final class StrTransformTest extends HackTest {
         darray[],
         'hello world',
       ),
+      tuple(
+        'hello world',
+        dict[
+          'o' => '0',
+          '0' => 'o',
+        ],
+        'hello world',
+      ),
+      tuple(
+        'hello world',
+        dict[
+          'hello' => 'hi',
+          'hi' => 'hello',
+        ],
+        'hello world',
+      ),
+      tuple(
+        'hi hello world hello hello',
+        dict[
+          'hello' => 'hi',
+          'hi' => 'hello',
+        ],
+        'hello hello world hello hello',
+      ),
     ];
   }
 
@@ -374,6 +398,30 @@ final class StrTransformTest extends HackTest {
         darray[],
         'hello world',
       ),
+      tuple(
+        'hello wOrld',
+        dict[
+          'o' => '0',
+          '0' => 'o',
+        ],
+        'hello world',
+      ),
+      tuple(
+        'Hello world',
+        dict[
+          'hello' => 'hi',
+          'hi' => 'hello',
+        ],
+        'hello world',
+      ),
+      tuple(
+        'HI hello world Hello HELLO',
+        dict[
+          'hello' => 'hi',
+          'hi' => 'hello',
+        ],
+        'hello hello world hello hello',
+      ),
     ];
   }
 
@@ -384,6 +432,112 @@ final class StrTransformTest extends HackTest {
     string $expected,
   ): void {
     expect(Str\replace_every_ci($haystack, $replacements))->toEqual($expected);
+  }
+
+  public static function provideReplaceEveryNonrecursive(): varray<mixed> {
+    return varray[
+      tuple(
+        'hello world',
+        dict[
+          'h' => 'H',
+          'w' => 'W',
+        ],
+        'Hello World',
+      ),
+      tuple(
+        'Hello world',
+        dict[
+          'h' => 'H',
+          'H' => 'h',
+          'w' => 'W',
+          'W' => 'w',
+        ],
+        'hello World',
+      ),
+      tuple(
+        'hello world',
+        dict[
+          'hello' => 'hi',
+          'world' => 'universe',
+        ],
+        'hi universe',
+      ),
+      tuple(
+        'Hi hello world hello hi',
+        dict[
+          'hello' => 'hi',
+          'hi' => 'Hello',
+        ],
+        'Hi hi world hi Hello',
+      ),
+    ];
+  }
+
+  <<DataProvider('provideReplaceEveryNonrecursive')>>
+  public function testReplaceEveryNonrecursive(
+    string $haystack,
+    KeyedContainer<string, string> $replacements,
+    string $expected,
+  ): void {
+    expect(Str\replace_every_nonrecursive($haystack, $replacements))->toBeSame($expected);
+  }
+
+  public function testReplaceEveryNonrecursiveExceptions(): void {
+    expect(() ==> Str\replace_every_nonrecursive('hello world', dict['h' => 'H', '' => 'W']))
+      ->toThrow(InvariantException::class);
+  }
+
+  public static function provideReplaceEveryNonrecursiveCI(): varray<mixed> {
+    return varray[
+      tuple(
+        'Hello World',
+        dict[
+          'h' => 'H',
+          'w' => 'W',
+        ],
+        'Hello World',
+      ),
+      tuple(
+        'Hello world',
+        dict[
+          'h' => 'H',
+          'H' => 'h',
+          'w' => 'W',
+          'W' => 'w',
+        ],
+        'Hello World',
+      ),
+      tuple(
+        'Hello world',
+        dict[
+          'Hello' => 'hi',
+          'World' => 'universe',
+        ],
+        'hi universe',
+      ),
+      tuple(
+        'Hi hello world HELLO HI',
+        dict[
+          'HELLO' => 'hi',
+          'HI' => 'Hello',
+        ],
+        'Hello hi world hi Hello',
+      ),
+    ];
+  }
+
+  <<DataProvider('provideReplaceEveryNonrecursiveCI')>>
+  public function testReplaceEveryNonrecursiveCI(
+    string $haystack,
+    KeyedContainer<string, string> $replacements,
+    string $expected,
+  ): void {
+    expect(Str\replace_every_nonrecursive_ci($haystack, $replacements))->toBeSame($expected);
+  }
+
+  public function testReplaceEveryNonrecursiveCIExceptions(): void {
+    expect(() ==> Str\replace_every_nonrecursive_ci('hello world', dict['h' => 'H', '' => 'W']))
+      ->toThrow(InvariantException::class);
   }
 
   public static function providerReverse(): vec<(string, string)> {

--- a/tests/str/StrTransformTest.php
+++ b/tests/str/StrTransformTest.php
@@ -487,17 +487,17 @@ final class StrTransformTest extends HackTest {
       ->toThrow(InvariantException::class);
   }
 
-  public static function provideReplaceEveryNonrecursiveCI(): varray<mixed> {
-    return varray[
-      tuple(
-        'Hello World',
+  public static function provideReplaceEveryNonrecursiveCI(): dict<string, (string, dict<string, string>, string)> {
+    return dict[
+      'Replace lowercase letter with uppercase' => tuple(
+        'Hello world',
         dict[
           'h' => 'H',
           'w' => 'W',
         ],
         'Hello World',
       ),
-      tuple(
+      'Replace multi character strings' => tuple(
         'Hello world',
         dict[
           'Hello' => 'hi',
@@ -505,13 +505,45 @@ final class StrTransformTest extends HackTest {
         ],
         'hi universe',
       ),
-      tuple(
+      'Replace both upper and lowercase strings with differing cases' => tuple(
         'Hi hello world HELLO HI',
         dict[
           'HELLO' => 'hi',
           'HI' => 'Hello',
         ],
         'Hello hi world hi Hello',
+      ),
+      'When a replacer is a prefix of another, the longer one wins' => tuple(
+        '12345',
+        dict[
+          '12' => 'FAIL',
+          '1234' => 'SUCCESS',
+        ],
+        'SUCCESS5',
+      ),
+      "Replacers do not look at the replacements from previous iterations" => tuple(
+        'sub fast',
+        dict[
+          'sub' => 'subject',
+          'bject' => 'FAIL',
+        ],
+        'subject fast',
+      ),
+      "Replacement does not skip a beat if the replacement is shorter than the replacer" => tuple(
+        'red black rEd blAck',
+        dict[
+          'ed' => 'acecars',
+          'lack' => 'ook cover',
+        ],
+        'racecars book cover racecars book cover',
+      ),
+      "Can handle if one replacer is a substring of another and pick the whole" => tuple(
+        'banana',
+        dict[
+          'na' => 'FAIL',
+          'banana' => 'SUCCESS',
+        ],
+        'SUCCESS',
       ),
     ];
   }


### PR DESCRIPTION
closes #82

Finish implementing Str\replace_every_nonrecursive_ci().

Big thanks to Arthur for doing all the hard thinking work on how to implement this algorithm.
I just had to address Ján's comments.

I asked permission to finish this via Slack:
> L: Do you want to finish it yourself or would you want me to address Ján's comments?
> A: would be great if you had some time to finish it indeed