### PR TITLE
Require HHVM/Hack 4.60

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,9 @@ sudo: required
 language: generic
 services: docker
 env:
-- HHVM_VERSION=4.41-latest
+- HHVM_VERSION=4.60-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly
-matrix:
-  allow_failures:
-    - env: HHVM_VERSION=4.18-latest
-    - env: HHVM_VERSION=latest
 install:
 - docker pull hhvm/hhvm:$HHVM_VERSION
 script:

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
     "hhvm/hsl-experimental": "^4.37|dev-master"
   },
   "require": {
-    "hhvm": "^4.41"
+    "hhvm": "^4.60"
   }
 }


### PR DESCRIPTION
This release is from last week, and is the oldest one that's compatible
with reactivity changes.

Also, removed allowed-failures:
- one version was stale
- this was primarily there so that bots wouldn't nag FB employees about
things they can't fix; that bot is dead.

Test plan: TravisCI
