### PR TITLE
Add C\pop_back as replacements for \array_pop

### DIFF
--- a/src/c/select.php
+++ b/src/c/select.php
@@ -395,3 +395,49 @@ function onlyx<T>(
   /* HH_FIXME[4110] $first is false implies $result is set to T */
   return $result;
 }
+
+/**
+ * Removes the last element from a Container and returns it.
+ * If the Container is empty, null will be returned.
+ *
+ * When an immutable Hack Collection is passed, the result will
+ * be defined by your version of hhvm and not give the expected results.
+ *
+ * For non-empty Containers, see `pop_backx`.
+ * For removing the first element, see `pop_front` and `pop_frontx`.
+ *
+ * Time complexity: O(1 or N) If the operation can happen in-place, O(1)
+ *   if it must copy the Container, O(N).
+ * Space complexity: O(1 or N) If the operation can happen in-place, O(1)
+ *   if it must copy the Container, O(N).
+ */
+function pop_back<T as Container<Tv>, Tv>(inout T $container): ?Tv {
+  if (is_empty($container)) {
+    return null;
+  }
+  return \array_pop(inout $container);
+}
+
+/**
+ * Removes the last element from a Container and returns it.
+ * If the Container is empty, an `InvariantException` is thrown.
+ *
+ * When an immutable Hack Collection is passed, the result will
+ * be defined by your version of hhvm and not give the expected results.
+ *
+ * For maybe empty Containers, see `pop_back`.
+ * For removing the first element, see `pop_front` and `pop_frontx`.
+ *
+ * Time complexity: O(1 or N) If the operation can happen in-place, O(1)
+ *   if it must copy the Container, O(N).
+ * Space complexity: O(1 or N) If the operation can happen in-place, O(1)
+ *   if it must copy the Container, O(N).
+ */
+function pop_backx<T as Container<Tv>, Tv>(inout T $container): Tv {
+  invariant(
+    !is_empty($container),
+    '%s: Expected at least one element',
+    __FUNCTION__,
+  );
+  return \array_pop(inout $container);
+}

--- a/tests/c/CSelectTest.php
+++ b/tests/c/CSelectTest.php
@@ -790,4 +790,83 @@ final class CSelectTest extends HackTest {
     )
       ->toEqual(42);
   }
+
+  public function provideTestPopBack(
+  ): vec<(Container<mixed>, Container<mixed>, mixed)> {
+    return vec[
+      tuple(vec[1], vec[], 1),
+      tuple(vec[1, 2, 3], vec[1, 2], 3),
+      tuple(vec[], vec[], null),
+      tuple(keyset['apple', 'banana'], keyset['apple'], 'banana'),
+      tuple(varray[1, 2, 3], varray[1, 2], 3),
+      tuple(dict['a' => 1, 'b' => 2], dict['a' => 1], 2),
+      tuple(Vector {1, 2, 3}, Vector {1, 2}, 3),
+      tuple(Set {}, Set {}, null),
+    ];
+  }
+
+  <<DataProvider('provideTestPopBack')>>
+  public function testPopBack(
+    Container<mixed> $before,
+    Container<mixed> $after,
+    mixed $value,
+  ): void {
+    $return_value = C\pop_back(inout $before);
+    invariant(
+      $after is KeyedContainer<_, _>,
+      '->toHaveSameContentAs() takes a KeyedContainer.'.
+      'There are currently no Containers in Hack which are not also KeyedContainers.',
+    );
+    expect($before)->toHaveSameContentAs($after);
+    expect($return_value)->toEqual($value);
+  }
+
+  public function provideTestPopBackx(
+  ): vec<(Container<mixed>, Container<mixed>, mixed)> {
+    return vec[
+      tuple(vec[1], vec[], 1),
+      tuple(vec[1, 2, 3], vec[1, 2], 3),
+      tuple(keyset['apple', 'banana'], keyset['apple'], 'banana'),
+      tuple(varray[1, 2, 3], varray[1, 2], 3),
+      tuple(dict['a' => 1, 'b' => 2], dict['a' => 1], 2),
+      tuple(Vector {1, 2, 3}, Vector {1, 2}, 3),
+    ];
+  }
+
+  <<DataProvider('provideTestPopBackx')>>
+  public function testPopBackx(
+    Container<mixed> $before,
+    Container<mixed> $after,
+    mixed $value,
+  ): void {
+    $return_value = C\pop_backx(inout $before);
+    invariant(
+      $after is KeyedContainer<_, _>,
+      '->toHaveSameContentAs() takes a KeyedContainer.'.
+      'There are currently no Containers in Hack which are not also KeyedContainers.',
+    );
+    expect($before)->toHaveSameContentAs($after);
+    expect($return_value)->toEqual($value);
+  }
+
+  public function provideTestPopBackxThrowsOnEmptyContainers(
+  ): vec<(Container<mixed>)> {
+    return vec[
+      tuple(vec[]),
+      tuple(dict[]),
+      tuple(keyset[]),
+      tuple(Vector {}),
+      tuple(Map {}),
+    ];
+  }
+
+  <<DataProvider('provideTestPopBackxThrowsOnEmptyContainers')>>
+  public function testPopBackxThrowOnEmptyContainers(
+    Container<mixed> $container,
+  ): void {
+    expect(() ==> C\pop_backx(inout $container))->toThrow(
+      InvariantException::class,
+      'Expected at least one element',
+    );
+  }
 }


### PR DESCRIPTION
fixes #137
references https://github.com/hhvm/hsl-experimental/issues/86#issuecomment-567271062

This name (and hopefully its behavior) is identical to `Vec\fb\pop_back()`.

An argument could be made that `C\fb\pop_back()` is better named. However, this version only operates on vecs (like the issue comment), so `Vec\` seems to me like a fitting namespace. Also, if unordered `Container<_>`s are added to hhvm, the semantics of popping them would become unclear. I believe `arraylike<_>` is a migrational type, so I didn't use it, but that would do nicely here too.