### PR TITLE
HHVM+HSL compatibility fixes

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -6,4 +6,4 @@ unsafe_rx = false
 ignored_paths = [ "vendor/.+/tests/.+" ]
 user_attributes=
 allowed_decl_fixme_codes=2053,4045
-allowed_fixme_codes_strict=2011,2049,2050,2053,4027,4045,4106,4107,4108,4110,4128,4135,4188,4200,4240,4248,4297,4323,4387
+allowed_fixme_codes_strict=2011,2049,2050,2053,4027,4045,4106,4107,4108,4110,4128,4135,4188,4200,4240,4248,4259,4297,4323,4387

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: generic
 services: docker
 env:
-- HHVM_VERSION=4.62-latest
+- HHVM_VERSION=4.72-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly
 install:

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
     "hhvm/hsl-experimental": "^4.37|dev-master"
   },
   "require": {
-    "hhvm": "^4.62"
+    "hhvm": "^4.72"
   }
 }

--- a/src/dict/order.php
+++ b/src/dict/order.php
@@ -70,12 +70,12 @@ function sort<Tk as arraykey, Tv>(
 ): dict<Tk, Tv> {
   $result = dict($traversable);
   if ($value_comparator) {
-    /* HH_FIXME[4200] Rx calling non-rx */
+    /* HH_FIXME[4387] __Pure calling impure */
     /* HH_FIXME[2049] __PHPStdLib */
     /* HH_FIXME[4107] __PHPStdLib */
     \uasort(inout $result, $value_comparator);
   } else {
-    /* HH_FIXME[4200] Rx calling non-rx */
+    /* HH_FIXME[4387] __Pure calling impure */
     /* HH_FIXME[2049] __PHPStdLib */
     /* HH_FIXME[4107] __PHPStdLib */
     \asort(inout $result);
@@ -134,12 +134,12 @@ function sort_by_key<Tk as arraykey, Tv>(
 ): dict<Tk, Tv> {
   $result = dict($traversable);
   if ($key_comparator) {
-    /* HH_FIXME[4200] Rx calling non-rx */
+    /* HH_FIXME[4387] __Pure calling impure */
     /* HH_FIXME[2049] __PHPStdLib */
     /* HH_FIXME[4107] __PHPStdLib */
     \uksort(inout $result, $key_comparator);
   } else {
-    /* HH_FIXME[4200] Calling non-rx */
+    /* HH_FIXME[4387] __Pure calling impure */
     /* HH_FIXME[2049] __PHPStdLib */
     /* HH_FIXME[4107] __PHPStdLib */
     \ksort(inout $result);

--- a/src/keyset/order.php
+++ b/src/keyset/order.php
@@ -27,12 +27,12 @@ function sort<Tv as arraykey>(
 ): keyset<Tv> {
   $keyset = keyset($traversable);
   if ($comparator) {
-    /* HH_FIXME[4200] Rx calling non-Rx */
+    /* HH_FIXME[4387] __Pure calling impure */
     /* HH_FIXME[2049] __PHPStdLib */
     /* HH_FIXME[4107] __PHPStdLib */
     \uksort(inout $keyset, $comparator);
   } else {
-    /* HH_FIXME[4200] Rx calling non-Rx */
+    /* HH_FIXME[4387] __Pure calling impure */
     /* HH_FIXME[2049] __PHPStdLib */
     /* HH_FIXME[4107] __PHPStdLib */
     \ksort(inout $keyset);

--- a/src/vec/order.php
+++ b/src/vec/order.php
@@ -102,12 +102,12 @@ function sort<Tv>(
   if ($comparator) {
     /* HH_FIXME[2049] calling stdlib directly */
     /* HH_FIXME[4107] calling stdlib directly */
-    /* HH_FIXME[4200] Rx calling non-rx */
+    /* HH_FIXME[4387] __Pure calling impure */
     \usort(inout $vec, $comparator);
   } else {
     /* HH_FIXME[2049] calling stdlib directly */
     /* HH_FIXME[4107] calling stdlib directly */
-    /* HH_FIXME[4200] Rx calling non-rx */
+    /* HH_FIXME[4387] __Pure calling impure */
     \sort(inout $vec);
   }
   return $vec;
@@ -140,12 +140,12 @@ function sort_by<Tv, Ts>(
   if ($comparator) {
     /* HH_FIXME[2049] calling stdlib directly */
     /* HH_FIXME[4107] calling stdlib directly */
-    /* HH_FIXME[4200] Rx calling non-rx */
+    /* HH_FIXME[4387] __Pure calling impure */
     \uasort(inout $order_by, $comparator);
   } else {
     /* HH_FIXME[2049] calling stdlib directly */
     /* HH_FIXME[4107] calling stdlib directly */
-    /* HH_FIXME[4200] Rx calling non-rx */
+    /* HH_FIXME[4387] __Pure calling impure */
     \asort(inout $order_by);
   }
   return map_with_key($order_by, ($k, $v) ==> $vec[$k]);


### PR DESCRIPTION
- bump minimum version to HHVM 4.72, required for `\HH\array_unmark_legacy`
- add missing FIXME number to .hhconfig
- change some Rx FIXMEs to purity FIXMEs in functions that were changed from Rx to Pure