### PR TITLE
Bump minimum version to 4.79

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: generic
 services: docker
 env:
-- HHVM_VERSION=4.72-latest
+- HHVM_VERSION=4.79-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly
 install:

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
     "hhvm/hsl-experimental": "^4.37|dev-master"
   },
   "require": {
-    "hhvm": "^4.72"
+    "hhvm": "^4.79"
   }
 }


### PR DESCRIPTION
The HSL now include native function reference (function pointer) syntax.
This is incompatible with hhvm 4.78 and below.