### PR TITLE
remove coeffects flags, bump HHVM version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu ]
         hhvm:
-          - '4.92'
+          - '4.93'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest
@@ -59,8 +59,8 @@ jobs:
       - name: Install project dependencies
         run: php ${{runner.temp}}/composer.phar install --no-autoloader
       - name: Generate autoload map
-        run: hhvm -c hhvm.ini vendor/bin/hh-autoload
+        run: hhvm vendor/bin/hh-autoload
       - name: Typecheck
         run: hh_client
       - name: Run tests
-        run: hhvm -c hhvm.ini vendor/bin/hacktest tests/
+        run: hhvm vendor/bin/hacktest tests/

--- a/.hhconfig
+++ b/.hhconfig
@@ -7,6 +7,3 @@ ignored_paths = [ "vendor/.+/tests/.+" ]
 user_attributes=
 allowed_decl_fixme_codes=2053,4045
 allowed_fixme_codes_strict=2011,2049,2050,2053,4027,4045,4106,4107,4108,4110,4128,4135,4188,4200,4240,4248,4259,4297,4323,4387,4390,4401
-enable_coeffects_syntax=true
-call_coeffects=true
-local_coeffects=true

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
     "hhvm/hsl-experimental": "^4.37|dev-master"
   },
   "require": {
-    "hhvm": "^4.79"
+    "hhvm": "^4.93"
   }
 }

--- a/hhvm.ini
+++ b/hhvm.ini
@@ -1,1 +1,0 @@
-hhvm.hack.lang.enable_coeffects=true


### PR DESCRIPTION
These are on by default as of today's HHVM release.