### PR TITLE
require HHVM 4.94

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu ]
         hhvm:
-          - '4.93'
+          - '4.94'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
     "hhvm/hsl-experimental": "^4.37|dev-master"
   },
   "require": {
-    "hhvm": "^4.93"
+    "hhvm": "^4.94"
   }
 }


### PR DESCRIPTION
HSL now references the `write_props` context which was not added until HHVM 4.94 (https://github.com/facebook/hhvm/commit/5228a9ab7bf2947e6ed6ee890db65e27d5dfb902)