### PR TITLE
Bring back public HSL testing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,17 +11,25 @@ jobs:
       # Run tests on all OS's and HHVM versions, even if one fails
       fail-fast: false
       matrix:
-        os: [ ubuntu ]
+        os: [ ubuntu, macos ]
         hhvm:
-          - '4.108'
-          - latest
           - nightly
     runs-on: ${{matrix.os}}-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Create branch for version alias
-        run: git checkout -b CI_current_pull_request
-      - uses: hhvm/actions/hack-lint-test@master
+      - name: "Install hack"
+        uses: hhvm/actions/install-hack@master
         with:
           hhvm: ${{matrix.hhvm}}
-          skip_lint: true
+      - name: Print HHVM version
+        run: hhvm --version
+      - name: Install Watchman (apt)
+        if: ${{ matrix.os == 'ubuntu' }}
+        run: DEBIAN_FRONTEND=noninteractive sudo apt install -y watchman
+      - name: Install Watchman (brew)
+        if: ${{ matrix.os == 'macos' }}
+        run: brew install watchman
+      - name: Typecheck
+        run: hh_client
+      - name: Run tests
+        run: ./minitest.sh

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
       # Run tests on all OS's and HHVM versions, even if one fails
       fail-fast: false
       matrix:
-        os: [ ubuntu, macos ]
+        os: [ ubuntu ]
         hhvm:
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,11 @@ jobs:
         run: |
           DEBIAN_FRONTEND=noninteractive \
           sudo apt install -y locales
-          sudo locale-gen en_US fr_FR tr_TR en_US.UTF-8 fr_FR.UTF-8 tr_TR.UTF-8
+          sudo locale-gen \
+            en_US en_US.UTF-8 \
+            fr_FR fr_FR.UTF-8 \
+            tr_TR tr_TR.UTF-8 \
+            da_DK da_DK.UTF-8
       - name: Install Watchman (brew)
         if: ${{ matrix.os == 'macos' }}
         run: brew install watchman

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Install Watchman (apt)
         if: ${{ matrix.os == 'ubuntu' }}
         run: DEBIAN_FRONTEND=noninteractive sudo apt install -y watchman
+      - name: Install locale support (apt)
+        if: ${{ matrix.os == 'ubuntu' }}
+        run: |
+          DEBIAN_FRONTEND=noninteractive \
+          sudo apt install -y locales
+          sudo locale-gen en_US fr_FR tr_TR en_US.UTF-8 fr_FR.UTF-8 tr_TR.UTF-8
       - name: Install Watchman (brew)
         if: ${{ matrix.os == 'macos' }}
         run: brew install watchman

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,14 @@
-vendor/
+/vendor/
 *.hhast.parser-cache
 *.swp
 *~
-.var/
+/.var/
 composer.lock
+
+# If you checkout the github repository on an FB-issued Machine, you'll need
+# to create this file with `echo '{}' > .watchmanconfig`, due to the
+# Facebook-specific configuration in /etc
+/.watchmanconfig
 
 # Dune aggressivly cleans its' build directory, so the generated HHIs have to
 # be outside of Dune's build directory

--- a/tests/locale/LocaleTest.php
+++ b/tests/locale/LocaleTest.php
@@ -51,7 +51,7 @@ final class LocaleTest extends HackTest {
       // Make sure the `\setlocale()` worked
       expect(\sprintf("%.02f", 1.23))->toEqual('1.23');
 
-      $l = Locale\create('fr_FR.UTF8');
+      $l = Locale\create('fr_FR.UTF-8');
       expect(_Str\strlen_l("💩", $l))->toEqual(1);
       expect(_Str\vsprintf_l($l, "%.02f", vec[1.23]))->toEqual('1,23');
     } finally {


### PR DESCRIPTION
- one test change: the `fr_FR.UTF8` locale that was used in the test is not valid, and must be `fr_FR.UTF-8`. Some environments (including FB's CI environment) are forgiving about this, others aren't. Test the correct thing
- only target nightly builds as now that the HSL is bundled with HHVM, we do not need compatibility with other versions
- add dependencies for built-in autoloader and locale tests
- update .gitignore
- do not test on MacOS for now: str purity/locale support has some portability issues that need to be fixed in HHVM itself

Test Plan:

- public run: https://github.com/fredemmott/hsl/actions/runs/1492315037
- legocastle runs + //hphp/hsl/... buck tests