### PR TITLE
Fix HSL locale tests on MacOS

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
       # Run tests on all OS's and HHVM versions, even if one fails
       fail-fast: false
       matrix:
-        os: [ ubuntu ]
+        os: [ ubuntu, macos ]
         hhvm:
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/tests/str/StrLocaleTest.php
+++ b/tests/str/StrLocaleTest.php
@@ -25,8 +25,8 @@ final class StrLocaleTest extends HackTest {
   public function testSystemDefaultEncoding(): void {
     // This is undefined behavior, but let's make sure that we act like
     // everything else on the current platform
-    $emoji = "😀😀";
-    $actual = Str\slice_l(Locale\create('en_US'), $emoji, 1, 1);
+    $emoji = "😀☹️";
+    $actual = Str\slice_l(Locale\create('en_US'), $emoji, 0, 1);
     if (\HH\Lib\_Private\_OS\IS_MACOS) {
       // UTF-8
       expect($actual)->toEqual("😀");

--- a/tests/str/StrLocaleTest.php
+++ b/tests/str/StrLocaleTest.php
@@ -8,7 +8,7 @@
  *
  */
 
-use namespace HH\Lib\{Locale, OS};
+use namespace HH\Lib\{Locale, OS, Str};
 use function HH\__Private\MiniTest\expect;
 use type HH\__Private\MiniTest\{DataProvider, HackTest};
 

--- a/tests/str/StrLocaleTest.php
+++ b/tests/str/StrLocaleTest.php
@@ -25,7 +25,7 @@ final class StrLocaleTest extends HackTest {
   public function testSystemDefaultEncoding(): void {
     // This is undefined behavior, but let's make sure that we act like
     // everything else on the current platform
-    $emoji = "😀😀"
+    $emoji = "😀😀";
     $actual = Str\slice_l(Locale\create('en_US'), 1, 1);
     if (\HH\Lib\_Private\_OS\IS_MACOS) {
       // UTF-8

--- a/tests/str/StrLocaleTest.php
+++ b/tests/str/StrLocaleTest.php
@@ -8,7 +8,7 @@
  *
  */
 
-use namespace HH\Lib\{Locale, Str};
+use namespace HH\Lib\{Locale, OS};
 use function HH\__Private\MiniTest\expect;
 use type HH\__Private\MiniTest\{DataProvider, HackTest};
 
@@ -22,6 +22,20 @@ use type HH\__Private\MiniTest\{DataProvider, HackTest};
 // - "\u{00c9}": "É" as a single character
 // - "E\u{0301}": "É" as two characters, 'E', and a combining acute accent
 final class StrLocaleTest extends HackTest {
+  public function testSystemDefaultEncoding(): void {
+    // This is undefined behavior, but let's make sure that we act like
+    // everything else on the current platform
+    $emoji = "😀😀"
+    $actual = Str\slice_l(Locale\create('en_US'), 1, 1);
+    if (\HH\Lib\_Private\_OS\IS_MACOS) {
+      // UTF-8
+      expect($actual)->toEqual("😀");
+    } else {
+      // Single-byte (e.g. ASCII or ISO8859-1)
+      expect($actual)->toEqual("😀"[0]);
+    }
+  }
+
   public function testCapitalizeL(): void {
     expect(Str\capitalize_l(Locale\create('en_US'), 'ifoo'))
       ->toEqual('Ifoo');
@@ -44,7 +58,7 @@ final class StrLocaleTest extends HackTest {
     $emoji = "😀😀😀😀";
     expect(Str\chunk_l(Locale\c(), $emoji, 2))
       ->toEqual(\str_split($emoji, 2));
-    expect(Str\chunk_l(Locale\create('en_US'), $emoji, 2))
+    expect(Str\chunk_l(Locale\create('en_US.US-ASCII'), $emoji, 2))
       ->toEqual(\str_split($emoji, 2));
     expect(Str\chunk_l(Locale\create('en_US.UTF-8'), $emoji, 2))
       ->toEqual(vec["😀😀", "😀😀"]);
@@ -62,19 +76,18 @@ final class StrLocaleTest extends HackTest {
     $b = 'Æble';
     expect($b)->toEqual("\u{00c6}ble");
     expect($b)->toEqual("\xc3\x86ble");
-    $b_iso_8859_1 = "\xc6ble";
+    $b_iso8859_1 = "\xc6ble";
 
     expect(Str\compare_l(Locale\c(), $a, $b))->toBeLessThan(0);
-    expect(Str\compare_l(Locale\create('en_US'), $a, $b))->toBeGreaterThan(0);
+    expect(Str\compare_l(Locale\create('en_US.ISO8859-1'), $a, $b))->toBeGreaterThan(0);
     expect(Str\compare_l(Locale\create('en_US.UTF-8'), $a, $b))->toBeGreaterThan(0);
     // Danish has different sorting rules...
     expect(Str\compare_l(Locale\create('da_DK.UTF-8'), $a, $b))->toBeLessThan(0);
     // ... but if we don't specify UTF8, we have different behavior:
     //
     // In $b (UTF-8), 'Æ' is 0xc386, but da_DK is usually
-    // ISO-8859-1, which considers that to be two characters.
-    expect(Str\compare_l(Locale\create('da_DK'), $a, $b))->toBeGreaterThan(0);
-    expect(Str\compare_l(Locale\create('da_DK'), $a, $b_iso_8859_1))->toBeLessThan(0);
+    // ISO-8859-1 on Linux, which considers that to be two characters.
+    expect(Str\compare_l(Locale\create('da_DK.ISO8859-1'), $a, $b))->toBeGreaterThan(0);
   }
 
   public function testCompareCIL(): void {
@@ -98,7 +111,7 @@ final class StrLocaleTest extends HackTest {
     expect(Str\contains_l($l, $emoji, $emoji))->toBeTrue();
     expect(Str\contains_l($l, $emoji, $emoji[0]))->toBeTrue();
 
-    $l = Locale\create('en_US');
+    $l = Locale\create('en_US.US-ASCII');
     expect(Str\contains_l($l, $e_combined_acute, 'e'))->toBeTrue();
     expect(Str\contains_l($l, $e_acute, 'e'))->toBeFalse();
     expect(Str\contains_l($l, $e_combined_acute, $e_acute))->toBeFalse();
@@ -128,7 +141,7 @@ final class StrLocaleTest extends HackTest {
     expect(Str\contains_ci_l($l, $emoji, $emoji))->toBeTrue();
     expect(Str\contains_ci_l($l, $emoji, $emoji[0]))->toBeTrue();
 
-    $l = Locale\create('en_US');
+    $l = Locale\create('en_US.US-ASCII');
     expect(Str\contains_ci_l($l, $e_combined_acute, 'e'))->toBeTrue();
     expect(Str\contains_ci_l($l, $e_acute, 'e'))->toBeFalse();
     expect(Str\contains_ci_l($l, $e_combined_acute, $e_acute))->toBeFalse();
@@ -148,7 +161,7 @@ final class StrLocaleTest extends HackTest {
   public function testEndsWithL(): void {
     $def = "de\u{0301}f";
 
-    $l = Locale\create('en_US');
+    $l = Locale\create('en_US.US-ASCII');
     expect(Str\ends_with_l($l, $def, "e\u{0301}f"))->toBeTrue();
     expect(Str\ends_with_l($l, $def, "\u{00e9}f"))->toBeFalse();
     expect(Str\ends_with_l($l, $def, "E\u{0301}f"))->toBeFalse();
@@ -162,7 +175,7 @@ final class StrLocaleTest extends HackTest {
   public function testEndsWithCIL(): void {
     $def = "de\u{0301}f";
 
-    $l = Locale\create('en_US');
+    $l = Locale\create('en_US.US-ASCII');
     expect(Str\ends_with_ci_l($l, $def, "E\u{0301}f"))->toBeTrue();
     expect(Str\ends_with_ci_l($l, $def, "\u{00c9}f"))->toBeFalse();
 
@@ -174,12 +187,12 @@ final class StrLocaleTest extends HackTest {
   public function testLengthL(): void {
     $emoji = "😀😀😀😀";
     expect(Str\length_l(Locale\create('en_US.UTF-8'), $emoji))->toEqual(4);
-    expect(Str\length_l(Locale\create('en_US'), $emoji))->toEqual(16);
+    expect(Str\length_l(Locale\create('en_US.US-ASCII'), $emoji))->toEqual(16);
   }
 
   public function testLowercaseL(): void {
     expect(Str\lowercase_l(Locale\c(), "IFOO"))->toEqual('ifoo');
-    expect(Str\lowercase_l(Locale\create('en_US'), "IFOO"))->toEqual('ifoo');
+    expect(Str\lowercase_l(Locale\create('en_US.US-ASCII'), "IFOO"))->toEqual('ifoo');
     expect(Str\lowercase_l(Locale\create('en_US.UTF-8'), "IFOO"))->toEqual('ifoo');
     expect(Str\lowercase_l(Locale\create('tr_TR.UTF-8'), "IFOO"))->toEqual('ıfoo');
   }
@@ -187,7 +200,7 @@ final class StrLocaleTest extends HackTest {
   public function testPadLeftL(): void {
     $emoji = "😀😀😀😀";
     expect(Str\pad_left_l(Locale\c(), $emoji, 5, '!'))->toEqual($emoji);
-    expect(Str\pad_left_l(Locale\create('en_US'), $emoji, 5, '!'))->toEqual($emoji);
+    expect(Str\pad_left_l(Locale\create('en_US.US-ASCII'), $emoji, 5, '!'))->toEqual($emoji);
     expect(Str\pad_left_l(Locale\create('en_US.UTF-8'), $emoji, 5, '!'))->toEqual('!'.$emoji);
     expect(Str\pad_left_l(Locale\create('en_US.UTF-8'), $emoji, 6, '!'))->toEqual('!!'.$emoji);
     expect(Str\pad_left_l(Locale\create('en_US.UTF-8'), $emoji, 6, '😀'))->toEqual('😀😀'.$emoji);
@@ -196,7 +209,7 @@ final class StrLocaleTest extends HackTest {
   public function testPadRightL(): void {
     $emoji = "😀😀😀😀";
     expect(Str\pad_right_l(Locale\c(), $emoji, 5, '!'))->toEqual($emoji);
-    expect(Str\pad_right_l(Locale\create('en_US'), $emoji, 5, '!'))->toEqual($emoji);
+    expect(Str\pad_right_l(Locale\create('en_US.US-ASCII'), $emoji, 5, '!'))->toEqual($emoji);
     expect(Str\pad_right_l(Locale\create('en_US.UTF-8'), $emoji, 5, '!'))->toEqual($emoji.'!');
     expect(Str\pad_right_l(Locale\create('en_US.UTF-8'), $emoji, 6, '!'))->toEqual($emoji.'!!');
     expect(Str\pad_right_l(Locale\create('en_US.UTF-8'), $emoji, 6, '😀'))->toEqual($emoji.'😀😀');
@@ -205,7 +218,7 @@ final class StrLocaleTest extends HackTest {
   public function testReplaceL(): void {
     $def = "de\u{0301}f";
 
-    $l = Locale\create('en_US');
+    $l = Locale\create('en_US.US-ASCII');
     expect(Str\replace_l($l, $def, 'e', 'E'))->toEqual("dE\u{0301}f");
     expect(Str\replace_l($l, $def, "\u{00e9}", '!'))->toEqual($def);
     expect(Str\replace_l($l, $def, "\u{00c9}", '!'))->toEqual($def);
@@ -219,7 +232,7 @@ final class StrLocaleTest extends HackTest {
   public function testReplaceCIL(): void {
     $def = "de\u{0301}f";
 
-    $l = Locale\create('en_US');
+    $l = Locale\create('en_US.US-ASCII');
     expect(Str\replace_ci_l($l, $def, 'e', 'E'))->toEqual("dE\u{0301}f");
     expect(Str\replace_ci_l($l, $def, "\u{00e9}", '!'))->toEqual($def);
     expect(Str\replace_ci_l($l, $def, "\u{00c9}", '!'))->toEqual($def);
@@ -240,9 +253,9 @@ final class StrLocaleTest extends HackTest {
     $emoji = '😀💩';
     $ijome = '💩😀';
 
-    expect(Str\reverse_l(Locale\create('en_US'), $emoji))
+    expect(Str\reverse_l(Locale\create('en_US.US-ASCII'), $emoji))
       ->toNotEqual($ijome);
-    expect(Str\reverse_l(Locale\create('en_US'), $emoji))
+    expect(Str\reverse_l(Locale\create('en_US.US-ASCII'), $emoji))
       ->toEqual(\strrev($emoji));
 
     expect(Str\reverse_l(Locale\create('en_US.UTF-8'), $emoji))
@@ -252,7 +265,7 @@ final class StrLocaleTest extends HackTest {
   public function testSearchL(): void {
     $def = "de\u{0301}f";
 
-    $l = Locale\create('en_US');
+    $l = Locale\create('en_US.US-ASCII');
     expect(Str\search_l($l, $def, 'e'))->toEqual(1);
     expect(Str\search_l($l, $def, 'f'))->toEqual(4);
     expect(Str\search_l($l, $def, 'F'))->toEqual(null);
@@ -266,7 +279,7 @@ final class StrLocaleTest extends HackTest {
   public function testSearchCIL(): void {
     $def = "de\u{0301}f";
 
-    $l = Locale\create('en_US');
+    $l = Locale\create('en_US.US-ASCII');
     expect(Str\search_ci_l($l, $def, 'e'))->toEqual(1);
     expect(Str\search_ci_l($l, $def, 'f'))->toEqual(4);
     expect(Str\search_ci_l($l, $def, 'F'))->toEqual(4);
@@ -280,7 +293,7 @@ final class StrLocaleTest extends HackTest {
   public function testSearchLastL(): void {
     $def = "d\u{00e9}fde\u{0301}f";
 
-    $l = Locale\create('en_US');
+    $l = Locale\create('en_US.US-ASCII');
     expect(Str\search_last_l($l, $def, 'e'))->toEqual(5);
     expect(Str\search_last_l($l, $def, "\u{00e9}"))->toEqual(1);
     expect(Str\search_last_l($l, $def, "E"))->toEqual(null);
@@ -295,7 +308,7 @@ final class StrLocaleTest extends HackTest {
 
   public function testSliceL(): void {
     $emoji = "😀😀😀😀";
-    expect(Str\slice_l(Locale\create('en_US'), $emoji, 0, 2))
+    expect(Str\slice_l(Locale\create('en_US.US-ASCII'), $emoji, 0, 2))
       ->toEqual(\substr($emoji, 0, 2));
     expect(Str\slice_l(Locale\create('en_US.UTF-8'), $emoji, 0, 2))
       ->toNotEqual(\substr($emoji, 0, 2));
@@ -305,7 +318,7 @@ final class StrLocaleTest extends HackTest {
 
   public function testSpliceL(): void {
     $def = "de\u{0301}f";
-    expect(Str\splice_l(Locale\create('en_US'), $def, 'E', 1, 1))
+    expect(Str\splice_l(Locale\create('en_US.US-ASCII'), $def, 'E', 1, 1))
       ->toEqual("dE\u{0301}f");
     expect(Str\splice_l(Locale\create('en_US.UTF-8'), $def, 'E', 1, 1))
       ->toEqual("dEf");
@@ -334,7 +347,7 @@ final class StrLocaleTest extends HackTest {
   public function testStartsWithL(): void {
     $def = "de\u{0301}f";
 
-    $l = Locale\create('en_US');
+    $l = Locale\create('en_US.US-ASCII');
     expect(Str\starts_with_l($l, $def, "de\u{0301}"))->toBeTrue();
     expect(Str\starts_with_l($l, $def, "d\u{00e9}"))->toBeFalse();
     expect(Str\starts_with_l($l, $def, "dE\u{0301}"))->toBeFalse();
@@ -348,7 +361,7 @@ final class StrLocaleTest extends HackTest {
   public function testStartsWithCIL(): void {
     $def = "de\u{0301}f";
 
-    $l = Locale\create('en_US');
+    $l = Locale\create('en_US.US-ASCII');
     expect(Str\starts_with_ci_l($l, $def, "de\u{0301}"))->toBeTrue();
     expect(Str\starts_with_ci_l($l, $def, "d\u{00e9}"))->toBeFalse();
     expect(Str\starts_with_ci_l($l, $def, "dE\u{0301}"))->toBeTrue();
@@ -362,7 +375,7 @@ final class StrLocaleTest extends HackTest {
   public function testStripPrefixL(): void {
     $def = "de\u{0301}f";
 
-    expect(Str\strip_prefix_l(Locale\create('en_US'), $def, "d\u{00e9}"))
+    expect(Str\strip_prefix_l(Locale\create('en_US.US-ASCII'), $def, "d\u{00e9}"))
       ->toEqual($def);
     expect(Str\strip_prefix_l(Locale\create('en_US.UTF-8'), $def, "d\u{00e9}"))
       ->toEqual('f');
@@ -371,7 +384,7 @@ final class StrLocaleTest extends HackTest {
   public function testStripSuffixL(): void {
     $def = "de\u{0301}f";
 
-    expect(Str\strip_suffix_l(Locale\create('en_US'), $def, "\u{00e9}f"))
+    expect(Str\strip_suffix_l(Locale\create('en_US.US-ASCII'), $def, "\u{00e9}f"))
       ->toEqual($def);
     expect(Str\strip_suffix_l(Locale\create('en_US.UTF-8'), $def, "\u{00e9}f"))
       ->toEqual('d');
@@ -380,7 +393,7 @@ final class StrLocaleTest extends HackTest {
   public function testTrimL(): void {
     // \u{00a0} is unicode non-breaking space
     $sample = " \u{00a0}!\u{00a0} ";
-    expect(Str\trim_l(Locale\create('en_US'), $sample))
+    expect(Str\trim_l(Locale\create('en_US.US-ASCII'), $sample))
       ->toEqual("\u{00a0}!\u{00a0}");
     expect(Str\trim_l(Locale\create('en_US.UTF-8'), $sample))
       ->toEqual("!");
@@ -389,7 +402,7 @@ final class StrLocaleTest extends HackTest {
   public function testTrimLeftL(): void {
     // 00a0 == nbsp
     $sample = " \u{00a0}!\u{00a0} ";
-    expect(Str\trim_left_l(Locale\create('en_US'), $sample))
+    expect(Str\trim_left_l(Locale\create('en_US.US-ASCII'), $sample))
       ->toEqual("\u{00a0}!\u{00a0} ");
     expect(Str\trim_left_l(Locale\create('en_US.UTF-8'), $sample))
       ->toEqual("!\u{00a0} ");
@@ -398,7 +411,7 @@ final class StrLocaleTest extends HackTest {
   public function testTrimRightL(): void {
     // 00a0 == nbsp
     $sample = " \u{00a0}!\u{00a0} ";
-    expect(Str\trim_right_l(Locale\create('en_US'), $sample))
+    expect(Str\trim_right_l(Locale\create('en_US.US-ASCII'), $sample))
       ->toEqual(" \u{00a0}!\u{00a0}");
     expect(Str\trim_right_l(Locale\create('en_US.UTF-8'), $sample))
       ->toEqual(" \u{00a0}!");

--- a/tests/str/StrLocaleTest.php
+++ b/tests/str/StrLocaleTest.php
@@ -26,7 +26,7 @@ final class StrLocaleTest extends HackTest {
     // This is undefined behavior, but let's make sure that we act like
     // everything else on the current platform
     $emoji = "😀😀";
-    $actual = Str\slice_l(Locale\create('en_US'), 1, 1);
+    $actual = Str\slice_l(Locale\create('en_US'), $emoji, 1, 1);
     if (\HH\Lib\_Private\_OS\IS_MACOS) {
       // UTF-8
       expect($actual)->toEqual("😀");

--- a/tests/str/StrLocaleTest.php
+++ b/tests/str/StrLocaleTest.php
@@ -58,7 +58,7 @@ final class StrLocaleTest extends HackTest {
     $emoji = "😀😀😀😀";
     expect(Str\chunk_l(Locale\c(), $emoji, 2))
       ->toEqual(\str_split($emoji, 2));
-    expect(Str\chunk_l(Locale\create('en_US.US-ASCII'), $emoji, 2))
+    expect(Str\chunk_l(Locale\create('en_US.ISO8859-1'), $emoji, 2))
       ->toEqual(\str_split($emoji, 2));
     expect(Str\chunk_l(Locale\create('en_US.UTF-8'), $emoji, 2))
       ->toEqual(vec["😀😀", "😀😀"]);
@@ -111,7 +111,7 @@ final class StrLocaleTest extends HackTest {
     expect(Str\contains_l($l, $emoji, $emoji))->toBeTrue();
     expect(Str\contains_l($l, $emoji, $emoji[0]))->toBeTrue();
 
-    $l = Locale\create('en_US.US-ASCII');
+    $l = Locale\create('en_US.ISO8859-1');
     expect(Str\contains_l($l, $e_combined_acute, 'e'))->toBeTrue();
     expect(Str\contains_l($l, $e_acute, 'e'))->toBeFalse();
     expect(Str\contains_l($l, $e_combined_acute, $e_acute))->toBeFalse();
@@ -141,7 +141,7 @@ final class StrLocaleTest extends HackTest {
     expect(Str\contains_ci_l($l, $emoji, $emoji))->toBeTrue();
     expect(Str\contains_ci_l($l, $emoji, $emoji[0]))->toBeTrue();
 
-    $l = Locale\create('en_US.US-ASCII');
+    $l = Locale\create('en_US.ISO8859-1');
     expect(Str\contains_ci_l($l, $e_combined_acute, 'e'))->toBeTrue();
     expect(Str\contains_ci_l($l, $e_acute, 'e'))->toBeFalse();
     expect(Str\contains_ci_l($l, $e_combined_acute, $e_acute))->toBeFalse();
@@ -161,7 +161,7 @@ final class StrLocaleTest extends HackTest {
   public function testEndsWithL(): void {
     $def = "de\u{0301}f";
 
-    $l = Locale\create('en_US.US-ASCII');
+    $l = Locale\create('en_US.ISO8859-1');
     expect(Str\ends_with_l($l, $def, "e\u{0301}f"))->toBeTrue();
     expect(Str\ends_with_l($l, $def, "\u{00e9}f"))->toBeFalse();
     expect(Str\ends_with_l($l, $def, "E\u{0301}f"))->toBeFalse();
@@ -175,7 +175,7 @@ final class StrLocaleTest extends HackTest {
   public function testEndsWithCIL(): void {
     $def = "de\u{0301}f";
 
-    $l = Locale\create('en_US.US-ASCII');
+    $l = Locale\create('en_US.ISO8859-1');
     expect(Str\ends_with_ci_l($l, $def, "E\u{0301}f"))->toBeTrue();
     expect(Str\ends_with_ci_l($l, $def, "\u{00c9}f"))->toBeFalse();
 
@@ -187,12 +187,12 @@ final class StrLocaleTest extends HackTest {
   public function testLengthL(): void {
     $emoji = "😀😀😀😀";
     expect(Str\length_l(Locale\create('en_US.UTF-8'), $emoji))->toEqual(4);
-    expect(Str\length_l(Locale\create('en_US.US-ASCII'), $emoji))->toEqual(16);
+    expect(Str\length_l(Locale\create('en_US.ISO8859-1'), $emoji))->toEqual(16);
   }
 
   public function testLowercaseL(): void {
     expect(Str\lowercase_l(Locale\c(), "IFOO"))->toEqual('ifoo');
-    expect(Str\lowercase_l(Locale\create('en_US.US-ASCII'), "IFOO"))->toEqual('ifoo');
+    expect(Str\lowercase_l(Locale\create('en_US.ISO8859-1'), "IFOO"))->toEqual('ifoo');
     expect(Str\lowercase_l(Locale\create('en_US.UTF-8'), "IFOO"))->toEqual('ifoo');
     expect(Str\lowercase_l(Locale\create('tr_TR.UTF-8'), "IFOO"))->toEqual('ıfoo');
   }
@@ -200,7 +200,7 @@ final class StrLocaleTest extends HackTest {
   public function testPadLeftL(): void {
     $emoji = "😀😀😀😀";
     expect(Str\pad_left_l(Locale\c(), $emoji, 5, '!'))->toEqual($emoji);
-    expect(Str\pad_left_l(Locale\create('en_US.US-ASCII'), $emoji, 5, '!'))->toEqual($emoji);
+    expect(Str\pad_left_l(Locale\create('en_US.ISO8859-1'), $emoji, 5, '!'))->toEqual($emoji);
     expect(Str\pad_left_l(Locale\create('en_US.UTF-8'), $emoji, 5, '!'))->toEqual('!'.$emoji);
     expect(Str\pad_left_l(Locale\create('en_US.UTF-8'), $emoji, 6, '!'))->toEqual('!!'.$emoji);
     expect(Str\pad_left_l(Locale\create('en_US.UTF-8'), $emoji, 6, '😀'))->toEqual('😀😀'.$emoji);
@@ -209,7 +209,7 @@ final class StrLocaleTest extends HackTest {
   public function testPadRightL(): void {
     $emoji = "😀😀😀😀";
     expect(Str\pad_right_l(Locale\c(), $emoji, 5, '!'))->toEqual($emoji);
-    expect(Str\pad_right_l(Locale\create('en_US.US-ASCII'), $emoji, 5, '!'))->toEqual($emoji);
+    expect(Str\pad_right_l(Locale\create('en_US.ISO8859-1'), $emoji, 5, '!'))->toEqual($emoji);
     expect(Str\pad_right_l(Locale\create('en_US.UTF-8'), $emoji, 5, '!'))->toEqual($emoji.'!');
     expect(Str\pad_right_l(Locale\create('en_US.UTF-8'), $emoji, 6, '!'))->toEqual($emoji.'!!');
     expect(Str\pad_right_l(Locale\create('en_US.UTF-8'), $emoji, 6, '😀'))->toEqual($emoji.'😀😀');
@@ -218,7 +218,7 @@ final class StrLocaleTest extends HackTest {
   public function testReplaceL(): void {
     $def = "de\u{0301}f";
 
-    $l = Locale\create('en_US.US-ASCII');
+    $l = Locale\create('en_US.ISO8859-1');
     expect(Str\replace_l($l, $def, 'e', 'E'))->toEqual("dE\u{0301}f");
     expect(Str\replace_l($l, $def, "\u{00e9}", '!'))->toEqual($def);
     expect(Str\replace_l($l, $def, "\u{00c9}", '!'))->toEqual($def);
@@ -232,7 +232,7 @@ final class StrLocaleTest extends HackTest {
   public function testReplaceCIL(): void {
     $def = "de\u{0301}f";
 
-    $l = Locale\create('en_US.US-ASCII');
+    $l = Locale\create('en_US.ISO8859-1');
     expect(Str\replace_ci_l($l, $def, 'e', 'E'))->toEqual("dE\u{0301}f");
     expect(Str\replace_ci_l($l, $def, "\u{00e9}", '!'))->toEqual($def);
     expect(Str\replace_ci_l($l, $def, "\u{00c9}", '!'))->toEqual($def);
@@ -253,9 +253,9 @@ final class StrLocaleTest extends HackTest {
     $emoji = '😀💩';
     $ijome = '💩😀';
 
-    expect(Str\reverse_l(Locale\create('en_US.US-ASCII'), $emoji))
+    expect(Str\reverse_l(Locale\create('en_US.ISO8859-1'), $emoji))
       ->toNotEqual($ijome);
-    expect(Str\reverse_l(Locale\create('en_US.US-ASCII'), $emoji))
+    expect(Str\reverse_l(Locale\create('en_US.ISO8859-1'), $emoji))
       ->toEqual(\strrev($emoji));
 
     expect(Str\reverse_l(Locale\create('en_US.UTF-8'), $emoji))
@@ -265,7 +265,7 @@ final class StrLocaleTest extends HackTest {
   public function testSearchL(): void {
     $def = "de\u{0301}f";
 
-    $l = Locale\create('en_US.US-ASCII');
+    $l = Locale\create('en_US.ISO8859-1');
     expect(Str\search_l($l, $def, 'e'))->toEqual(1);
     expect(Str\search_l($l, $def, 'f'))->toEqual(4);
     expect(Str\search_l($l, $def, 'F'))->toEqual(null);
@@ -279,7 +279,7 @@ final class StrLocaleTest extends HackTest {
   public function testSearchCIL(): void {
     $def = "de\u{0301}f";
 
-    $l = Locale\create('en_US.US-ASCII');
+    $l = Locale\create('en_US.ISO8859-1');
     expect(Str\search_ci_l($l, $def, 'e'))->toEqual(1);
     expect(Str\search_ci_l($l, $def, 'f'))->toEqual(4);
     expect(Str\search_ci_l($l, $def, 'F'))->toEqual(4);
@@ -293,7 +293,7 @@ final class StrLocaleTest extends HackTest {
   public function testSearchLastL(): void {
     $def = "d\u{00e9}fde\u{0301}f";
 
-    $l = Locale\create('en_US.US-ASCII');
+    $l = Locale\create('en_US.ISO8859-1');
     expect(Str\search_last_l($l, $def, 'e'))->toEqual(5);
     expect(Str\search_last_l($l, $def, "\u{00e9}"))->toEqual(1);
     expect(Str\search_last_l($l, $def, "E"))->toEqual(null);
@@ -308,7 +308,7 @@ final class StrLocaleTest extends HackTest {
 
   public function testSliceL(): void {
     $emoji = "😀😀😀😀";
-    expect(Str\slice_l(Locale\create('en_US.US-ASCII'), $emoji, 0, 2))
+    expect(Str\slice_l(Locale\create('en_US.ISO8859-1'), $emoji, 0, 2))
       ->toEqual(\substr($emoji, 0, 2));
     expect(Str\slice_l(Locale\create('en_US.UTF-8'), $emoji, 0, 2))
       ->toNotEqual(\substr($emoji, 0, 2));
@@ -318,7 +318,7 @@ final class StrLocaleTest extends HackTest {
 
   public function testSpliceL(): void {
     $def = "de\u{0301}f";
-    expect(Str\splice_l(Locale\create('en_US.US-ASCII'), $def, 'E', 1, 1))
+    expect(Str\splice_l(Locale\create('en_US.ISO8859-1'), $def, 'E', 1, 1))
       ->toEqual("dE\u{0301}f");
     expect(Str\splice_l(Locale\create('en_US.UTF-8'), $def, 'E', 1, 1))
       ->toEqual("dEf");
@@ -347,7 +347,7 @@ final class StrLocaleTest extends HackTest {
   public function testStartsWithL(): void {
     $def = "de\u{0301}f";
 
-    $l = Locale\create('en_US.US-ASCII');
+    $l = Locale\create('en_US.ISO8859-1');
     expect(Str\starts_with_l($l, $def, "de\u{0301}"))->toBeTrue();
     expect(Str\starts_with_l($l, $def, "d\u{00e9}"))->toBeFalse();
     expect(Str\starts_with_l($l, $def, "dE\u{0301}"))->toBeFalse();
@@ -361,7 +361,7 @@ final class StrLocaleTest extends HackTest {
   public function testStartsWithCIL(): void {
     $def = "de\u{0301}f";
 
-    $l = Locale\create('en_US.US-ASCII');
+    $l = Locale\create('en_US.ISO8859-1');
     expect(Str\starts_with_ci_l($l, $def, "de\u{0301}"))->toBeTrue();
     expect(Str\starts_with_ci_l($l, $def, "d\u{00e9}"))->toBeFalse();
     expect(Str\starts_with_ci_l($l, $def, "dE\u{0301}"))->toBeTrue();
@@ -375,7 +375,7 @@ final class StrLocaleTest extends HackTest {
   public function testStripPrefixL(): void {
     $def = "de\u{0301}f";
 
-    expect(Str\strip_prefix_l(Locale\create('en_US.US-ASCII'), $def, "d\u{00e9}"))
+    expect(Str\strip_prefix_l(Locale\create('en_US.ISO8859-1'), $def, "d\u{00e9}"))
       ->toEqual($def);
     expect(Str\strip_prefix_l(Locale\create('en_US.UTF-8'), $def, "d\u{00e9}"))
       ->toEqual('f');
@@ -384,7 +384,7 @@ final class StrLocaleTest extends HackTest {
   public function testStripSuffixL(): void {
     $def = "de\u{0301}f";
 
-    expect(Str\strip_suffix_l(Locale\create('en_US.US-ASCII'), $def, "\u{00e9}f"))
+    expect(Str\strip_suffix_l(Locale\create('en_US.ISO8859-1'), $def, "\u{00e9}f"))
       ->toEqual($def);
     expect(Str\strip_suffix_l(Locale\create('en_US.UTF-8'), $def, "\u{00e9}f"))
       ->toEqual('d');
@@ -393,7 +393,7 @@ final class StrLocaleTest extends HackTest {
   public function testTrimL(): void {
     // \u{00a0} is unicode non-breaking space
     $sample = " \u{00a0}!\u{00a0} ";
-    expect(Str\trim_l(Locale\create('en_US.US-ASCII'), $sample))
+    expect(Str\trim_l(Locale\create('en_US.ISO8859-1'), $sample))
       ->toEqual("\u{00a0}!\u{00a0}");
     expect(Str\trim_l(Locale\create('en_US.UTF-8'), $sample))
       ->toEqual("!");
@@ -402,7 +402,7 @@ final class StrLocaleTest extends HackTest {
   public function testTrimLeftL(): void {
     // 00a0 == nbsp
     $sample = " \u{00a0}!\u{00a0} ";
-    expect(Str\trim_left_l(Locale\create('en_US.US-ASCII'), $sample))
+    expect(Str\trim_left_l(Locale\create('en_US.ISO8859-1'), $sample))
       ->toEqual("\u{00a0}!\u{00a0} ");
     expect(Str\trim_left_l(Locale\create('en_US.UTF-8'), $sample))
       ->toEqual("!\u{00a0} ");
@@ -411,7 +411,7 @@ final class StrLocaleTest extends HackTest {
   public function testTrimRightL(): void {
     // 00a0 == nbsp
     $sample = " \u{00a0}!\u{00a0} ";
-    expect(Str\trim_right_l(Locale\create('en_US.US-ASCII'), $sample))
+    expect(Str\trim_right_l(Locale\create('en_US.ISO8859-1'), $sample))
       ->toEqual(" \u{00a0}!\u{00a0}");
     expect(Str\trim_right_l(Locale\create('en_US.UTF-8'), $sample))
       ->toEqual(" \u{00a0}!");


### PR DESCRIPTION
This test was previously testing undefined behavior.
- specify the encoding to make it defined where practical
- delete tests of other stuff like how sort order handles characters
  that are not valid in the current encoding.

The entire format of locale strings  is implementation-defined in POSIX;
`foo_BAR[.ENCODING]` is just a common convention, and there does not
appear to be a convention for default encodings.

fixes https://github.com/hhvm/hsl/issues/165

I filed that issue as I was worried it might be handled inconsistently;
it's not, we're correctly detecting it as a multi-byte locale here:

https://github.com/facebook/hhvm/blob/7e621926354146812f1d9532614947270e1e7ff2/hphp/runtime/base/locale.cpp#L130-L139

I think this is the better thing to do as:
- hack stuff will meet user expectations when encoding is specified
- it would be pretty reasonable to lint to require an explicit encoding
- if C library calls and subprocesses interpret the locale differently to how
  Hack/the HSL do, that seems like a potential source of bugs
