### PR TITLE
Add _File\relative_path

### DIFF
--- a/src/file/_Private/relative_path.php
+++ b/src/file/_Private/relative_path.php
@@ -1,0 +1,28 @@
+<?hh
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the hphp/hsl/ subdirectory of this source tree.
+ *
+ */
+
+namespace HH\Lib\_Private\_File;
+
+use namespace HH\Lib\Str;
+
+// Resolve a path relative to some directory.
+// This function is expected to be used internally in HSL only, instead of as a
+// general utility.
+// We need a sophiticated path library based on std::filesystem::canonical or
+// something in folly in the future.
+function relative_path(string $path, ?string $relative_to = null): string {
+  if (
+    Str\starts_with($path, '/') || Str\is_empty($relative_to)
+  ) {
+    return $path;
+  } else {
+    return $relative_to.'/'.$path;
+  }
+}

--- a/tests/file/RelativePathTest.php
+++ b/tests/file/RelativePathTest.php
@@ -1,0 +1,43 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the hphp/hsl/ subdirectory of this source tree.
+ *
+ */
+
+
+use function HH\__Private\MiniTest\expect;
+use type HH\__Private\MiniTest\HackTest;
+use namespace HH\Lib\_Private\_File;
+final class RelativePathTest extends HackTest {
+
+  public async function testBasic(): Awaitable<void> {
+    $real_path = _File\relative_path(
+      'baz',
+      'foo/bar',
+    );
+    expect($real_path)->toEqual('foo/bar/baz');
+  }
+
+  public async function testDot(): Awaitable<void> {
+    $real_path = \realpath(_File\relative_path(
+      './DictSelectTest.php',
+      _File\relative_path('../dict', __DIR__),
+    ));
+    expect($real_path)->toContainSubstring('/tests/dict/DictSelectTest.php');
+  }
+
+  public async function testSlash(): Awaitable<void> {
+    $path = _File\relative_path('/bin/sh', 'path/to/whatever');
+    expect($path)->toEqual('/bin/sh');
+  }
+
+  public async function testNull(): Awaitable<void> {
+    $path = _File\relative_path('path/to/file', null);
+    expect($path)->toEqual('path/to/file');
+  }
+
+}


### PR DESCRIPTION
This PR adds the `relative_path` function, which will be used in #178 

Test Plan:
```
./minitest.sh
```