### PR TITLE
Drop macOS from CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
       # Run tests on all OS's and HHVM versions, even if one fails
       fail-fast: false
       matrix:
-        os: [ ubuntu, macos ]
+        os: [ ubuntu ]
         hhvm:
           - nightly
     runs-on: ${{matrix.os}}-latest


### PR DESCRIPTION
Since we are not releasing HHVM on Homebrew on mac any more, the CI cannot pass on mac any more. Just drop it as it is unsupported.